### PR TITLE
Updated OMJulia function calls to new julia style

### DIFF
--- a/MagLevControlDesign.ipynb
+++ b/MagLevControlDesign.ipynb
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,16 +156,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "slideshow": {
      "slide_type": "subslide"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"OpenModelica 1.15.0~dev-45-g634bc00\""
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "omc = OMJulia.OMCSession()\n",
-    "omc.sendExpression(\"getVersion()\")"
+    "sendExpression(omc, \"getVersion()\")"
    ]
   },
   {
@@ -181,17 +192,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "slideshow": {
      "slide_type": "subslide"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Dict{Any,Any} with 10 entries:\n",
+       "  \"d_der0\" => \"None\"\n",
+       "  \"i0\"     => \"None\"\n",
+       "  \"m\"      => \"0.00302\"\n",
+       "  \"alpha\"  => \"2.44\"\n",
+       "  \"d0\"     => \"None\"\n",
+       "  \"gamma\"  => \"0.26\"\n",
+       "  \"k\"      => \"1.731e-08\"\n",
+       "  \"L\"      => \"0.01503\"\n",
+       "  \"R\"      => \"2.41\"\n",
+       "  \"beta\"   => \"0.000112\""
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "mlNL = OMJulia.OMCSession()\n",
-    "mlNL.ModelicaSystem(\"MagLevNL.mo\",  \"MagLevNL\")\n",
-    "mlNL.getParameters()"
+    "ModelicaSystem(mlNL, \"MagLevNL.mo\",  \"MagLevNL\")\n",
+    "getParameters(mlNL)"
    ]
   },
   {
@@ -234,8 +266,8 @@
     "\n",
     "```julia\n",
     "mlNL = OMJulia.OMCSession()\n",
-    "mlNL.ModelicaSystem(\"MagLevNL.mo\", \"MagLevNL\")\n",
-    "state_e, u_e, y_e = mlNL.findEquilibrium([\"d=0.02\", \"d_der=0\"])\n",
+    "ModelicaSystem(mlNL, \"MagLevNL.mo\", \"MagLevNL\")\n",
+    "state_e, u_e, y_e = findEquilibrium(mlNL, [\"d=0.02\", \"d_der=0\"])\n",
     "```\n",
     "\n",
     "But unfortunately no function `findEquilibrium` exists (yet).\n",
@@ -271,16 +303,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "v_e=0.66, i_e=0.27, d_e=0.02, d_der_e=0.00, e_e=2.79\n",
+      "A=[0.0 1.0 0.0; 1962.0 0.0 -35.82367549668874; 0.0 0.0 -160.3459747172322]\n",
+      "B=[0.0; 0.0; 66.53359946773121]\n",
+      "C=[-28.0 0.0 0.26]\n",
+      "D=[0.0]\n"
+     ]
+    }
+   ],
    "source": [
-    "using OMJulia, Printf\n",
+    "using OMJulia\n",
+    "using Printf\n",
     "mlNLe = OMJulia.OMCSession()\n",
-    "mlNLe.ModelicaSystem(\"MagLevNL_SteadyState.mo\", \"MagLevNL_SteadyState\")\n",
-    "mlNLe.setParameters([\"d0=0.02\"])\n",
-    "mlNLe.simulate()\n",
-    "sol = mlNLe.getSolutions([\"v\",\"i\",\"d\",\"d_der\",\"e\"])\n",
+    "ModelicaSystem(mlNLe, \"MagLevNL_SteadyState.mo\", \"MagLevNL_SteadyState\")\n",
+    "setParameters(mlNLe, [\"d0=0.02\"])\n",
+    "simulate(mlNLe)\n",
+    "sol = getSolutions(mlNLe, [\"v\",\"i\",\"d\",\"d_der\",\"e\"])\n",
     "v_e = sol[1][1] # input v at equilibrium\n",
     "i_e = sol[2][1] # state i at equilibrium\n",
     "d_e = sol[3][1] # state d, must be equal d0\n",
@@ -289,12 +334,11 @@
     "@printf(\"v_e=%0.2f, i_e=%0.2f, d_e=%0.2f, d_der_e=%0.2f, e_e=%0.2f\\n\", v_e, i_e, d_e, d_der_e, e_e)\n",
     "\n",
     "mlNL = OMJulia.OMCSession()\n",
-    "mlNL.ModelicaSystem(\"MagLevNL.mo\",\"MagLevNL\")\n",
-    "mlNL.setInputs([\"v=$v_e\"])\n",
-    "mlNL.setParameters([\"i0=$i_e\", \"d0=$d_e\", \"d_der0=$d_der_e\"])\n",
-    "A,B,C,D = mlNL.linearize()\n",
-    "println(\"A=\", A, \"\\nB=\", B, \"\\nC=\", C, \"\\nD=\", D)\n",
-    "#println(\"A=$A\\nB=$B\\nC=$C\\nD=$D\")\n"
+    "ModelicaSystem(mlNL, \"MagLevNL.mo\",\"MagLevNL\")\n",
+    "setInputs(mlNL, [\"v=$v_e\"])\n",
+    "setParameters(mlNL, [\"i0=$i_e\", \"d0=$d_e\", \"d_der0=$d_der_e\"])\n",
+    "A,B,C,D = linearize(mlNL)\n",
+    "println(\"A=\", A, \"\\nB=\", B, \"\\nC=\", C, \"\\nD=\", D)"
    ]
   },
   {
@@ -319,9 +363,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "StateSpace{Float64,Array{Float64,2}}\n",
+       "A = \n",
+       "    0.0  1.0     0.0             \n",
+       " 1962.0  0.0   -35.82367549668874\n",
+       "    0.0  0.0  -160.3459747172322 \n",
+       "B = \n",
+       "  0.0             \n",
+       "  0.0             \n",
+       " 66.53359946773121\n",
+       "C = \n",
+       " -28.0  0.0  0.26\n",
+       "D = \n",
+       " 0.0\n",
+       "\n",
+       "Continuous-time state-space model"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "using ControlSystems\n",
     "mlLin = ss(A,B,C,D)"
@@ -336,9 +405,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Array{Float64,1}:\n",
+       "   44.294469180700204\n",
+       "  -44.2944691807002  \n",
+       " -160.3459747172322  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pole(mlLin)"
    ]
@@ -352,9 +435,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TransferFunction{ControlSystems.SisoRational{Float64}}\n",
+       "   17.298735861610197*s^2 - 6.139089236967266e-12*s + 32797.26639436325\n",
+       "---------------------------------------------------------------------------\n",
+       "1.0*s^3 + 160.3459747172322*s^2 - 1962.0000000000011*s - 314598.80239520955\n",
+       "\n",
+       "Continuous-time transfer function model"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "G = tf(mlLin)"
    ]
@@ -393,10 +492,549 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<script>\n",
+       "// Immediately-invoked-function-expression to avoid global variables.\n",
+       "(function() {\n",
+       "    var warning_div = document.getElementById(\"webio-warning-6956472421548464697\");\n",
+       "    var hide = function () {\n",
+       "        var script = document.getElementById(\"webio-setup-13987500004169245744\");\n",
+       "        var parent = script && script.parentElement;\n",
+       "        var grandparent = parent && parent.parentElement;\n",
+       "        if (grandparent) {\n",
+       "            grandparent.style.display = \"none\";\n",
+       "        }\n",
+       "        warning_div.style.display = \"none\";\n",
+       "    };\n",
+       "    if (typeof Jupyter !== \"undefined\") {\n",
+       "        console.log(\"WebIO detected Jupyter notebook environment.\");\n",
+       "        // Jupyter notebook.\n",
+       "        var extensions = (\n",
+       "            Jupyter\n",
+       "            && Jupyter.notebook.config.data\n",
+       "            && Jupyter.notebook.config.data.load_extensions\n",
+       "        );\n",
+       "        if (extensions && extensions[\"webio-jupyter-notebook\"]) {\n",
+       "            // Extension already loaded.\n",
+       "            console.log(\"Jupyter WebIO nbextension detected; not loading ad-hoc.\");\n",
+       "            hide();\n",
+       "            return;\n",
+       "        }\n",
+       "    } else if (window.location.pathname.includes(\"/lab\")) {\n",
+       "        // Guessing JupyterLa\n",
+       "        console.log(\"Jupyter Lab detected; make sure the @webio/jupyter-lab-provider labextension is installed.\");\n",
+       "        hide();\n",
+       "        return;\n",
+       "    }\n",
+       "})();\n",
+       "\n",
+       "</script>\n",
+       "<p\n",
+       "    id=\"webio-warning-6956472421548464697\"\n",
+       "    class=\"output_text output_stderr\"\n",
+       "    style=\"padding: 1em; font-weight: bold;\"\n",
+       ">\n",
+       "    Unable to load WebIO. Please make sure WebIO works for your Jupyter client.\n",
+       "    For troubleshooting, please see <a href=\"https://juliagizmos.github.io/WebIO.jl/latest/providers/ijulia/\">\n",
+       "    the WebIO/IJulia documentation</a>.\n",
+       "    <!-- TODO: link to installation docs. -->\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "HTML{String}(\"<script>\\n// Immediately-invoked-function-expression to avoid global variables.\\n(function() {\\n    var warning_div = document.getElementById(\\\"webio-warning-6956472421548464697\\\");\\n    var hide = function () {\\n        var script = document.getElementById(\\\"webio-setup-13987500004169245744\\\");\\n        var parent = script && script.parentElement;\\n        var grandparent = parent && parent.parentElement;\\n        if (grandparent) {\\n            grandparent.style.display = \\\"none\\\";\\n        }\\n        warning_div.style.display = \\\"none\\\";\\n    };\\n    if (typeof Jupyter !== \\\"undefined\\\") {\\n        console.log(\\\"WebIO detected Jupyter notebook environment.\\\");\\n        // Jupyter notebook.\\n        var extensions = (\\n            Jupyter\\n            && Jupyter.notebook.config.data\\n            && Jupyter.notebook.config.data.load_extensions\\n        );\\n        if (extensions && extensions[\\\"webio-jupyter-notebook\\\"]) {\\n            // Extension already loaded.\\n            console.log(\\\"Jupyter WebIO nbextension detected; not loading ad-hoc.\\\");\\n            hide();\\n            return;\\n        }\\n    } else if (window.location.pathname.includes(\\\"/lab\\\")) {\\n        // Guessing JupyterLa\\n        console.log(\\\"Jupyter Lab detected; make sure the @webio/jupyter-lab-provider labextension is installed.\\\");\\n        hide();\\n        return;\\n    }\\n})();\\n\\n</script>\\n<p\\n    id=\\\"webio-warning-6956472421548464697\\\"\\n    class=\\\"output_text output_stderr\\\"\\n    style=\\\"padding: 1em; font-weight: bold;\\\"\\n>\\n    Unable to load WebIO. Please make sure WebIO works for your Jupyter client.\\n    For troubleshooting, please see <a href=\\\"https://juliagizmos.github.io/WebIO.jl/latest/providers/ijulia/\\\">\\n    the WebIO/IJulia documentation</a>.\\n    <!-- TODO: link to installation docs. -->\\n</p>\\n\")"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.webio.node+json": {
+       "children": [
+        {
+         "children": [
+          {
+           "children": [
+            {
+             "children": [
+              {
+               "children": [
+                {
+                 "children": [
+                  "Kp"
+                 ],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "label"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "className": "interact ",
+                  "style": {
+                   "padding": "5px 10px 0px 10px"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-left"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "input"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}",
+                   "orient": "horizontal",
+                   "type": "range"
+                  },
+                  "className": "slider slider is-fullwidth",
+                  "max": 35,
+                  "min": 1,
+                  "step": 1,
+                  "style": {}
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-center"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "p"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "text: formatted_val"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-right"
+               },
+               "type": "node"
+              }
+             ],
+             "instanceArgs": {
+              "namespace": "html",
+              "tag": "div"
+             },
+             "nodeType": "DOM",
+             "props": {
+              "className": "interact-flex-row interact-widget"
+             },
+             "type": "node"
+            }
+           ],
+           "instanceArgs": {
+            "handlers": {
+             "changes": [
+              "(function (val){return (val!=this.model[\"changes\"]()) ? (this.valueFromJulia[\"changes\"]=true, this.model[\"changes\"](val)) : undefined})"
+             ],
+             "index": [
+              "(function (val){return (val!=this.model[\"index\"]()) ? (this.valueFromJulia[\"index\"]=true, this.model[\"index\"](val)) : undefined})"
+             ]
+            },
+            "id": "18347416247943877564",
+            "imports": {
+             "data": [
+              {
+               "name": "knockout",
+               "type": "js",
+               "url": "/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js"
+              },
+              {
+               "name": "knockout_punches",
+               "type": "js",
+               "url": "/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js"
+              },
+              {
+               "name": null,
+               "type": "js",
+               "url": "/assetserver/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css"
+              }
+             ],
+             "type": "async_block"
+            },
+            "mount_callbacks": [
+             "function () {\n    var handler = (function (ko, koPunches) {\n    ko.punches.enableAll();\n    ko.bindingHandlers.numericValue = {\n        init: function(element, valueAccessor, allBindings, data, context) {\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\n            stringified.subscribe(function(value) {\n                var val = parseFloat(value);\n                if (!isNaN(val)) {\n                    valueAccessor()(val);\n                }\n            });\n            valueAccessor().subscribe(function(value) {\n                var str = JSON.stringify(value);\n                if ((str == \"0\") && ([\"-0\", \"-0.\"].indexOf(stringified()) >= 0))\n                     return;\n                 if ([\"null\", \"\"].indexOf(str) >= 0)\n                     return;\n                stringified(str);\n            });\n            ko.applyBindingsToNode(\n                element,\n                {\n                    value: stringified,\n                    valueUpdate: allBindings.get('valueUpdate'),\n                },\n                context,\n            );\n        }\n    };\n    var json_data = {\"formatted_vals\":[\"3.0\",\"3.5\",\"4.0\",\"4.5\",\"5.0\",\"5.5\",\"6.0\",\"6.5\",\"7.0\",\"7.5\",\"8.0\",\"8.5\",\"9.0\",\"9.5\",\"10.0\",\"10.5\",\"11.0\",\"11.5\",\"12.0\",\"12.5\",\"13.0\",\"13.5\",\"14.0\",\"14.5\",\"15.0\",\"15.5\",\"16.0\",\"16.5\",\"17.0\",\"17.5\",\"18.0\",\"18.5\",\"19.0\",\"19.5\",\"20.0\"],\"changes\":WebIO.getval({\"name\":\"changes\",\"scope\":\"18347416247943877564\",\"id\":\"ob_03\",\"type\":\"observable\"}),\"index\":WebIO.getval({\"name\":\"index\",\"scope\":\"18347416247943877564\",\"id\":\"ob_02\",\"type\":\"observable\"})};\n    var self = this;\n    function AppViewModel() {\n        for (var key in json_data) {\n            var el = json_data[key];\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\n        }\n        \n        [this[\"formatted_val\"]=ko.computed(    function(){\n        return this.formatted_vals()[parseInt(this.index())-(1)];\n    }\n,this)]\n        [this[\"changes\"].subscribe((function (val){!(this.valueFromJulia[\"changes\"]) ? (WebIO.setval({\"name\":\"changes\",\"scope\":\"18347416247943877564\",\"id\":\"ob_03\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"changes\"]=false}),self),this[\"index\"].subscribe((function (val){!(this.valueFromJulia[\"index\"]) ? (WebIO.setval({\"name\":\"index\",\"scope\":\"18347416247943877564\",\"id\":\"ob_02\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"index\"]=false}),self)]\n        \n    }\n    self.model = new AppViewModel();\n    self.valueFromJulia = {};\n    for (var key in json_data) {\n        self.valueFromJulia[key] = false;\n    }\n    ko.applyBindings(self.model, self.dom);\n}\n);\n    (WebIO.importBlock({\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"}],\"type\":\"async_block\"})).then((imports) => handler.apply(this, imports));\n}\n"
+            ],
+            "observables": {
+             "changes": {
+              "id": "ob_03",
+              "sync": false,
+              "value": 0
+             },
+             "index": {
+              "id": "ob_02",
+              "sync": true,
+              "value": 18
+             }
+            },
+            "systemjs_options": null
+           },
+           "nodeType": "Scope",
+           "props": {},
+           "type": "node"
+          }
+         ],
+         "instanceArgs": {
+          "namespace": "html",
+          "tag": "div"
+         },
+         "nodeType": "DOM",
+         "props": {
+          "className": "field interact-widget"
+         },
+         "type": "node"
+        },
+        {
+         "children": [
+          {
+           "children": [
+            {
+             "children": [
+              {
+               "children": [
+                {
+                 "children": [
+                  "Td"
+                 ],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "label"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "className": "interact ",
+                  "style": {
+                   "padding": "5px 10px 0px 10px"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-left"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "input"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}",
+                   "orient": "horizontal",
+                   "type": "range"
+                  },
+                  "className": "slider slider is-fullwidth",
+                  "max": 10,
+                  "min": 1,
+                  "step": 1,
+                  "style": {}
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-center"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "p"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "text: formatted_val"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-right"
+               },
+               "type": "node"
+              }
+             ],
+             "instanceArgs": {
+              "namespace": "html",
+              "tag": "div"
+             },
+             "nodeType": "DOM",
+             "props": {
+              "className": "interact-flex-row interact-widget"
+             },
+             "type": "node"
+            }
+           ],
+           "instanceArgs": {
+            "handlers": {
+             "changes": [
+              "(function (val){return (val!=this.model[\"changes\"]()) ? (this.valueFromJulia[\"changes\"]=true, this.model[\"changes\"](val)) : undefined})"
+             ],
+             "index": [
+              "(function (val){return (val!=this.model[\"index\"]()) ? (this.valueFromJulia[\"index\"]=true, this.model[\"index\"](val)) : undefined})"
+             ]
+            },
+            "id": "8588379458082123913",
+            "imports": {
+             "data": [
+              {
+               "name": "knockout",
+               "type": "js",
+               "url": "/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js"
+              },
+              {
+               "name": "knockout_punches",
+               "type": "js",
+               "url": "/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js"
+              },
+              {
+               "name": null,
+               "type": "js",
+               "url": "/assetserver/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css"
+              }
+             ],
+             "type": "async_block"
+            },
+            "mount_callbacks": [
+             "function () {\n    var handler = (function (ko, koPunches) {\n    ko.punches.enableAll();\n    ko.bindingHandlers.numericValue = {\n        init: function(element, valueAccessor, allBindings, data, context) {\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\n            stringified.subscribe(function(value) {\n                var val = parseFloat(value);\n                if (!isNaN(val)) {\n                    valueAccessor()(val);\n                }\n            });\n            valueAccessor().subscribe(function(value) {\n                var str = JSON.stringify(value);\n                if ((str == \"0\") && ([\"-0\", \"-0.\"].indexOf(stringified()) >= 0))\n                     return;\n                 if ([\"null\", \"\"].indexOf(str) >= 0)\n                     return;\n                stringified(str);\n            });\n            ko.applyBindingsToNode(\n                element,\n                {\n                    value: stringified,\n                    valueUpdate: allBindings.get('valueUpdate'),\n                },\n                context,\n            );\n        }\n    };\n    var json_data = {\"formatted_vals\":[\"0.01\",\"0.02\",\"0.03\",\"0.04\",\"0.05\",\"0.06\",\"0.07\",\"0.08\",\"0.09\",\"0.1\"],\"changes\":WebIO.getval({\"name\":\"changes\",\"scope\":\"8588379458082123913\",\"id\":\"ob_06\",\"type\":\"observable\"}),\"index\":WebIO.getval({\"name\":\"index\",\"scope\":\"8588379458082123913\",\"id\":\"ob_05\",\"type\":\"observable\"})};\n    var self = this;\n    function AppViewModel() {\n        for (var key in json_data) {\n            var el = json_data[key];\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\n        }\n        \n        [this[\"formatted_val\"]=ko.computed(    function(){\n        return this.formatted_vals()[parseInt(this.index())-(1)];\n    }\n,this)]\n        [this[\"changes\"].subscribe((function (val){!(this.valueFromJulia[\"changes\"]) ? (WebIO.setval({\"name\":\"changes\",\"scope\":\"8588379458082123913\",\"id\":\"ob_06\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"changes\"]=false}),self),this[\"index\"].subscribe((function (val){!(this.valueFromJulia[\"index\"]) ? (WebIO.setval({\"name\":\"index\",\"scope\":\"8588379458082123913\",\"id\":\"ob_05\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"index\"]=false}),self)]\n        \n    }\n    self.model = new AppViewModel();\n    self.valueFromJulia = {};\n    for (var key in json_data) {\n        self.valueFromJulia[key] = false;\n    }\n    ko.applyBindings(self.model, self.dom);\n}\n);\n    (WebIO.importBlock({\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"}],\"type\":\"async_block\"})).then((imports) => handler.apply(this, imports));\n}\n"
+            ],
+            "observables": {
+             "changes": {
+              "id": "ob_06",
+              "sync": false,
+              "value": 0
+             },
+             "index": {
+              "id": "ob_05",
+              "sync": true,
+              "value": 5
+             }
+            },
+            "systemjs_options": null
+           },
+           "nodeType": "Scope",
+           "props": {},
+           "type": "node"
+          }
+         ],
+         "instanceArgs": {
+          "namespace": "html",
+          "tag": "div"
+         },
+         "nodeType": "DOM",
+         "props": {
+          "className": "field interact-widget"
+         },
+         "type": "node"
+        },
+        {
+         "children": [
+          {
+           "children": [],
+           "instanceArgs": {
+            "id": "ob_12",
+            "name": "obs-node"
+           },
+           "nodeType": "ObservableNode",
+           "props": {},
+           "type": "node"
+          }
+         ],
+         "instanceArgs": {
+          "handlers": {},
+          "id": "2066687758994362241",
+          "imports": {
+           "data": [],
+           "type": "async_block"
+          },
+          "mount_callbacks": [],
+          "observables": {
+           "obs-node": {
+            "id": "ob_12",
+            "sync": false,
+            "value": {
+             "children": [
+              {
+               "children": [],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "setInnerHtml": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"600\" height=\"400\" viewBox=\"0 0 2400 1600\">\n<defs>\n  <clipPath id=\"clip1900\">\n    <rect x=\"0\" y=\"0\" width=\"2400\" height=\"1600\"/>\n  </clipPath>\n</defs>\n<path clip-path=\"url(#clip1900)\" d=\"\nM0 1600 L2400 1600 L2400 0 L0 0  Z\n  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n<defs>\n  <clipPath id=\"clip1901\">\n    <rect x=\"480\" y=\"0\" width=\"1681\" height=\"1600\"/>\n  </clipPath>\n</defs>\n<path clip-path=\"url(#clip1900)\" d=\"\nM215.754 1412.31 L2352.76 1412.31 L2352.76 121.675 L215.754 121.675  Z\n  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n<defs>\n  <clipPath id=\"clip1902\">\n    <rect x=\"215\" y=\"121\" width=\"2138\" height=\"1292\"/>\n  </clipPath>\n</defs>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  276.235,1412.31 276.235,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  478.531,1412.31 478.531,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  596.867,1412.31 596.867,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  680.828,1412.31 680.828,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  745.952,1412.31 745.952,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  799.163,1412.31 799.163,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  844.152,1412.31 844.152,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  883.124,1412.31 883.124,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  917.499,1412.31 917.499,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  948.248,1412.31 948.248,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1150.54,1412.31 1150.54,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1268.88,1412.31 1268.88,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1352.84,1412.31 1352.84,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1417.97,1412.31 1417.97,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1471.18,1412.31 1471.18,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1516.17,1412.31 1516.17,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1555.14,1412.31 1555.14,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1589.51,1412.31 1589.51,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1620.26,1412.31 1620.26,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1822.56,1412.31 1822.56,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1940.89,1412.31 1940.89,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2024.85,1412.31 2024.85,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2089.98,1412.31 2089.98,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2143.19,1412.31 2143.19,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2188.18,1412.31 2188.18,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2227.15,1412.31 2227.15,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2261.53,1412.31 2261.53,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2292.27,1412.31 2292.27,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,1399.37 2352.76,1399.37 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,1348.53 2352.76,1348.53 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,1297.7 2352.76,1297.7 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,1246.86 2352.76,1246.86 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,1196.02 2352.76,1196.02 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,1145.19 2352.76,1145.19 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,1094.35 2352.76,1094.35 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,1043.51 2352.76,1043.51 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,992.679 2352.76,992.679 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,941.843 2352.76,941.843 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,891.007 2352.76,891.007 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,840.171 2352.76,840.171 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,789.335 2352.76,789.335 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,738.498 2352.76,738.498 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,687.662 2352.76,687.662 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,636.826 2352.76,636.826 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,585.99 2352.76,585.99 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,535.154 2352.76,535.154 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,484.318 2352.76,484.318 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,433.482 2352.76,433.482 \n  \"/>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  215.754,382.646 2352.76,382.646 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1412.31 2352.76,1412.31 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1412.31 215.754,121.675 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  276.235,1412.31 276.235,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  478.531,1412.31 478.531,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  596.867,1412.31 596.867,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  680.828,1412.31 680.828,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  745.952,1412.31 745.952,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  799.163,1412.31 799.163,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  844.152,1412.31 844.152,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  883.124,1412.31 883.124,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  917.499,1412.31 917.499,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  948.248,1412.31 948.248,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1150.54,1412.31 1150.54,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1268.88,1412.31 1268.88,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1352.84,1412.31 1352.84,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1417.97,1412.31 1417.97,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1471.18,1412.31 1471.18,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1516.17,1412.31 1516.17,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1555.14,1412.31 1555.14,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1589.51,1412.31 1589.51,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1620.26,1412.31 1620.26,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1822.56,1412.31 1822.56,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1940.89,1412.31 1940.89,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2024.85,1412.31 2024.85,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2089.98,1412.31 2089.98,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2143.19,1412.31 2143.19,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2188.18,1412.31 2188.18,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2227.15,1412.31 2227.15,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2261.53,1412.31 2261.53,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2292.27,1412.31 2292.27,1396.82 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1399.37 241.398,1399.37 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1348.53 241.398,1348.53 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1297.7 241.398,1297.7 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1246.86 241.398,1246.86 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1196.02 241.398,1196.02 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1145.19 241.398,1145.19 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1094.35 241.398,1094.35 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,1043.51 241.398,1043.51 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,992.679 241.398,992.679 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,941.843 241.398,941.843 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,891.007 241.398,891.007 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,840.171 241.398,840.171 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,789.335 241.398,789.335 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,738.498 241.398,738.498 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,687.662 241.398,687.662 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,636.826 241.398,636.826 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,585.99 241.398,585.99 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,535.154 241.398,535.154 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,484.318 241.398,484.318 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,433.482 241.398,433.482 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  215.754,382.646 241.398,382.646 \n  \"/>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 238.601, 1487.32)\" x=\"238.601\" y=\"1487.32\">10</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 292.125, 1459.91)\" x=\"292.125\" y=\"1459.91\">0</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(478, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(596, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(680, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(745, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(799, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(844, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(883, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(917, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 910.614, 1487.32)\" x=\"910.614\" y=\"1487.32\">10</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 964.139, 1459.91)\" x=\"964.139\" y=\"1459.91\">1</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1150, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1268, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1352, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1417, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1471, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1516, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1555, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1589, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 1582.63, 1487.32)\" x=\"1582.63\" y=\"1487.32\">10</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 1636.15, 1459.91)\" x=\"1636.15\" y=\"1459.91\">2</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1822, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(1940, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(2024, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(2089, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(2143, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(2188, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(2227, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"1\" height=\"1\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4//8/AwAI/AL+hc2r\nNAAAAABJRU5ErkJggg==\n\" transform=\"translate(2261, 1423)\"/>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 2254.64, 1487.32)\" x=\"2254.64\" y=\"1487.32\">10</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 2308.16, 1459.91)\" x=\"2308.16\" y=\"1459.91\">3</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 1416.87)\" x=\"191.754\" y=\"1416.87\">0.0</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 1366.03)\" x=\"191.754\" y=\"1366.03\">0.2</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 1315.2)\" x=\"191.754\" y=\"1315.2\">0.4</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 1264.36)\" x=\"191.754\" y=\"1264.36\">0.6</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 1213.52)\" x=\"191.754\" y=\"1213.52\">0.8</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 1162.69)\" x=\"191.754\" y=\"1162.69\">1.0</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 1111.85)\" x=\"191.754\" y=\"1111.85\">1.2</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 1061.01)\" x=\"191.754\" y=\"1061.01\">1.4</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 1010.18)\" x=\"191.754\" y=\"1010.18\">1.6</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 959.343)\" x=\"191.754\" y=\"959.343\">1.8</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 908.507)\" x=\"191.754\" y=\"908.507\">2.0</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 857.671)\" x=\"191.754\" y=\"857.671\">2.2</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 806.835)\" x=\"191.754\" y=\"806.835\">2.4</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 755.998)\" x=\"191.754\" y=\"755.998\">2.6</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 705.162)\" x=\"191.754\" y=\"705.162\">2.8</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 654.326)\" x=\"191.754\" y=\"654.326\">3.0</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 603.49)\" x=\"191.754\" y=\"603.49\">3.2</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 552.654)\" x=\"191.754\" y=\"552.654\">3.4</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 501.818)\" x=\"191.754\" y=\"501.818\">3.6</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 450.982)\" x=\"191.754\" y=\"450.982\">3.8</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\" transform=\"rotate(0, 191.754, 400.146)\" x=\"191.754\" y=\"400.146\">4.0</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:84px; text-anchor:middle;\" transform=\"rotate(0, 1284.25, 73.2)\" x=\"1284.25\" y=\"73.2\">Sensitivity</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\" transform=\"rotate(0, 1284.25, 1566.14)\" x=\"1284.25\" y=\"1566.14\">Frequency (rad/s)</text>\n</g>\n<g clip-path=\"url(#clip1900)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\" transform=\"rotate(-90, 89.2861, 766.992)\" x=\"89.2861\" y=\"766.992\">Magnitude </text>\n</g>\n<polyline clip-path=\"url(#clip1902)\" style=\"stroke:#cc1414; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  276.235,158.202 286.366,160.725 296.497,163.41 306.628,166.269 316.759,169.309 326.89,172.543 337.02,175.979 347.151,179.629 357.282,183.503 367.413,187.614 \n  377.544,191.971 387.675,196.587 397.805,201.474 407.936,206.643 418.067,212.106 428.198,217.874 438.329,223.961 448.46,230.375 458.591,237.13 468.721,244.234 \n  478.852,251.699 488.983,259.532 499.114,267.743 509.245,276.338 519.376,285.325 529.507,294.708 539.637,304.491 549.768,314.677 559.899,325.265 570.03,336.255 \n  580.161,347.644 590.292,359.428 600.423,371.599 610.553,384.148 620.684,397.066 630.815,410.339 640.946,423.952 651.077,437.89 661.208,452.131 671.338,466.658 \n  681.469,481.446 691.6,496.473 701.731,511.713 711.862,527.139 721.993,542.725 732.124,558.442 742.254,574.261 752.385,590.153 762.516,606.088 772.647,622.036 \n  782.778,637.969 792.909,653.858 803.04,669.673 813.17,685.388 823.301,700.975 833.432,716.409 843.563,731.665 853.694,746.719 863.825,761.549 873.956,776.134 \n  884.086,790.454 894.217,804.49 904.348,818.226 914.479,831.645 924.61,844.732 934.741,857.475 944.871,869.86 955.002,881.876 965.133,893.513 975.264,904.761 \n  985.395,915.611 995.526,926.056 1005.66,936.087 1015.79,945.697 1025.92,954.881 1036.05,963.631 1046.18,971.943 1056.31,979.81 1066.44,987.226 1076.57,994.186 \n  1086.7,1000.68 1096.83,1006.72 1106.97,1012.28 1117.1,1017.36 1127.23,1021.97 1137.36,1026.09 1147.49,1029.74 1157.62,1032.9 1167.75,1035.59 1177.88,1037.82 \n  1188.01,1039.6 1198.14,1040.97 1208.27,1041.98 1218.4,1042.68 1228.54,1043.17 1238.67,1043.55 1248.8,1043.99 1258.93,1044.68 1269.06,1045.85 1279.19,1047.79 \n  1289.32,1050.8 1299.45,1055.17 1309.58,1061.2 1319.71,1069.07 1329.84,1078.86 1339.97,1090.51 1350.11,1103.8 1360.24,1118.39 1370.37,1133.85 1380.5,1149.74 \n  1390.63,1165.65 1400.76,1181.22 1410.89,1196.19 1421.02,1210.37 1431.15,1223.66 1441.28,1235.99 1451.41,1247.37 1461.54,1257.81 1471.68,1267.37 1481.81,1276.1 \n  1491.94,1284.06 1502.07,1291.31 1512.2,1297.92 1522.33,1303.95 1532.46,1309.45 1542.59,1314.48 1552.72,1319.07 1562.85,1323.28 1572.98,1327.13 1583.12,1330.67 \n  1593.25,1333.92 1603.38,1336.9 1613.51,1339.66 1623.64,1342.2 1633.77,1344.54 1643.9,1346.71 1654.03,1348.72 1664.16,1350.57 1674.29,1352.3 1684.42,1353.9 \n  1694.55,1355.38 1704.69,1356.76 1714.82,1358.05 1724.95,1359.25 1735.08,1360.36 1745.21,1361.4 1755.34,1362.37 1765.47,1363.27 1775.6,1364.11 1785.73,1364.9 \n  1795.86,1365.64 1805.99,1366.32 1816.12,1366.97 1826.26,1367.57 1836.39,1368.13 1846.52,1368.65 1856.65,1369.14 1866.78,1369.6 1876.91,1370.03 1887.04,1370.43 \n  1897.17,1370.81 1907.3,1371.16 1917.43,1371.48 1927.56,1371.79 1937.69,1372.08 1947.83,1372.34 1957.96,1372.59 1968.09,1372.83 1978.22,1373.05 1988.35,1373.25 \n  1998.48,1373.44 2008.61,1373.62 2018.74,1373.79 2028.87,1373.95 2039,1374.09 2049.13,1374.23 2059.27,1374.36 2069.4,1374.47 2079.53,1374.59 2089.66,1374.69 \n  2099.79,1374.79 2109.92,1374.88 2120.05,1374.96 2130.18,1375.04 2140.31,1375.11 2150.44,1375.18 2160.57,1375.25 2170.7,1375.31 2180.84,1375.36 2190.97,1375.42 \n  2201.1,1375.46 2211.23,1375.51 2221.36,1375.55 2231.49,1375.59 2241.62,1375.63 2251.75,1375.66 2261.88,1375.7 2272.01,1375.73 2282.14,1375.75 2292.27,1375.78 \n  \n  \"/>\n<path clip-path=\"url(#clip1900)\" d=\"\nM1989.76 326.155 L2280.76 326.155 L2280.76 205.195 L1989.76 205.195  Z\n  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1989.76,326.155 2280.76,326.155 2280.76,205.195 1989.76,205.195 1989.76,326.155 \n  \"/>\n<polyline clip-path=\"url(#clip1900)\" style=\"stroke:#cc1414; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2013.76,265.675 2157.76,265.675 \n  \"/>\n<g clip-path=\"url(#clip1900)\">\n<image width=\"51\" height=\"41\" xlink:href=\"data:image/png;base64,\niVBORw0KGgoAAAANSUhEUgAAADMAAAApCAYAAACY7BHXAAADfElEQVRogd1Z7Y2jMBAdohRgU4Kz\nFUALbAdmSyBbgZMSUgJJCWgrYLcEJxUAJTh08O7HHQhMPkgwudONNFJEyNhv/ObL8QCQazmfz+Cc\ne84N35HFVAPf39+I4xhhGIJzDs/z4Ps+eZ4HzjnW6zXKsrzqsc1mgziO3XgUwMOqtUaSJGCMgYhA\nRBBCQEoJpRTSNEWaplBKQQgBIkKSJLDt7HY7EBF2u93gu2f0oZeNMUiSpAXQbFJrfXMzWZaBMYYg\nCNB91ti493vnYNI0HYAwxozeRFEUYIwhiiLked6z5QLIaDBSynZhxhjyPH9qAzYIIkIURa8BY4xB\nEAS9uHjkNC5pFEU9MK7i5SaYhhYugVw6HVfxchNMk4UaarkA0i46Q7xcBWNTIcsyp4s2jupmt1nA\nKKV6QKSUThfsOkspNR8YrfUg27ikV6NNdnw2K44C081cc3jOPhnXdtsP3Yo856k0TnMdLwBo2fRo\n2+2217NFUURzdb5JkpDv++4N40qsuM5gr1AChhmMZuDzy8B0Kz3NlI5foYvj8Yi6rnvUi6LIPZ8d\nSVmW2O/3l4e5S1nMZb/kUrXWbb946fulMWYAMAzDl8/v16QsS5xOJzocDvTz83Pz3WVVVb0HQohJ\ni5/P59Hz/K3Uv9/v8fn5SUREjDH6+PigIAjodDpdN9gdvGjCsFQUxYCu9/RW4TTGoCiKXuHu7vUi\nzezixRgb69ierFYr78+sQnVdkzGGGnp0JQgC2m63xBi7yQLOucc5f2gPy6m06sr7+/uANofDoUe7\nLMtotVrNEpMLG4wdQ1PEvi8TQswGhIhoYdcUu+ZMETv7zF2/FpxzLwiC9kFVVQ9lpFvyajAEDC8Z\n0jR1UjTtNmnqSHEvm7UfuoMZY2wyGNtBQojJNu+BaS/OsyxrT6uua9psNpOo1hS8Rl7S73WR2X3a\nsxd0jQe7NHMxH42m2TVAUsrRXNdaQwgBxhi01ujacjGCPwwG+N2a2JcbSZIgz/PepowxyPMcSqn2\nfftCXUrpbN5/CkyjeZ7D7t0uqRACSikURXFxkWvPXYPxgHFxfjweUVVV2yEIIdr+as6q3pU4jvH1\n9UVERAAGay4Hv7giYRh6YRg63Jp7mfyf5r8k/xWY0TT7G9J03XVdk9a61+ut12tIKcn3fWKMke/7\n4xPAq6UsS7y9vY1+XylFvwBZDw9vFy4ANwAAAABJRU5ErkJggg==\n\" transform=\"translate(2182, 245)\"/>\n</g>\n</svg>\n"
+               },
+               "type": "node"
+              }
+             ],
+             "instanceArgs": {
+              "namespace": "html",
+              "tag": "div"
+             },
+             "nodeType": "DOM",
+             "props": {
+              "className": "interact-flex-row interact-widget"
+             },
+             "type": "node"
+            }
+           }
+          },
+          "systemjs_options": null
+         },
+         "nodeType": "Scope",
+         "props": {},
+         "type": "node"
+        }
+       ],
+       "instanceArgs": {
+        "namespace": "html",
+        "tag": "div"
+       },
+       "nodeType": "DOM",
+       "props": {},
+       "type": "node"
+      },
+      "text/html": [
+       "<div\n",
+       "    class=\"webio-mountpoint\"\n",
+       "    data-webio-mountpoint=\"1020870403091686237\"\n",
+       ">\n",
+       "    <script>\n",
+       "    if (window.require && require.defined && require.defined(\"nbextensions/webio-jupyter-notebook\")) {\n",
+       "        console.log(\"Jupyter WebIO extension detected, not mounting.\");\n",
+       "    } else if (window.WebIO) {\n",
+       "        WebIO.mount(\n",
+       "            document.querySelector('[data-webio-mountpoint=\"1020870403091686237\"]'),\n",
+       "            {\"props\":{},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"field interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{},\"nodeType\":\"Scope\",\"type\":\"node\",\"instanceArgs\":{\"imports\":{\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"},{\"name\":null,\"type\":\"js\",\"url\":\"\\/assetserver\\/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css\"}],\"type\":\"async_block\"},\"id\":\"18347416247943877564\",\"handlers\":{\"changes\":[\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\"],\"index\":[\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\"]},\"systemjs_options\":null,\"mount_callbacks\":[\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"3.0\\\",\\\"3.5\\\",\\\"4.0\\\",\\\"4.5\\\",\\\"5.0\\\",\\\"5.5\\\",\\\"6.0\\\",\\\"6.5\\\",\\\"7.0\\\",\\\"7.5\\\",\\\"8.0\\\",\\\"8.5\\\",\\\"9.0\\\",\\\"9.5\\\",\\\"10.0\\\",\\\"10.5\\\",\\\"11.0\\\",\\\"11.5\\\",\\\"12.0\\\",\\\"12.5\\\",\\\"13.0\\\",\\\"13.5\\\",\\\"14.0\\\",\\\"14.5\\\",\\\"15.0\\\",\\\"15.5\\\",\\\"16.0\\\",\\\"16.5\\\",\\\"17.0\\\",\\\"17.5\\\",\\\"18.0\\\",\\\"18.5\\\",\\\"19.0\\\",\\\"19.5\\\",\\\"20.0\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"18347416247943877564\\\",\\\"id\\\":\\\"ob_03\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"18347416247943877564\\\",\\\"id\\\":\\\"ob_02\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"18347416247943877564\\\",\\\"id\\\":\\\"ob_03\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"18347416247943877564\\\",\\\"id\\\":\\\"ob_02\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\"],\"observables\":{\"changes\":{\"sync\":false,\"id\":\"ob_03\",\"value\":0},\"index\":{\"sync\":true,\"id\":\"ob_02\",\"value\":18}}},\"children\":[{\"props\":{\"className\":\"interact-flex-row interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact-flex-row-left\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact \",\"style\":{\"padding\":\"5px 10px 0px 10px\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"label\"},\"children\":[\"Kp\"]}]},{\"props\":{\"className\":\"interact-flex-row-center\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"max\":35,\"min\":1,\"attributes\":{\"type\":\"range\",\"data-bind\":\"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\":\"horizontal\"},\"step\":1,\"className\":\"slider slider is-fullwidth\",\"style\":{}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"input\"},\"children\":[]}]},{\"props\":{\"className\":\"interact-flex-row-right\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"attributes\":{\"data-bind\":\"text: formatted_val\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"p\"},\"children\":[]}]}]}]}]},{\"props\":{\"className\":\"field interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{},\"nodeType\":\"Scope\",\"type\":\"node\",\"instanceArgs\":{\"imports\":{\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"},{\"name\":null,\"type\":\"js\",\"url\":\"\\/assetserver\\/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css\"}],\"type\":\"async_block\"},\"id\":\"8588379458082123913\",\"handlers\":{\"changes\":[\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\"],\"index\":[\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\"]},\"systemjs_options\":null,\"mount_callbacks\":[\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"0.01\\\",\\\"0.02\\\",\\\"0.03\\\",\\\"0.04\\\",\\\"0.05\\\",\\\"0.06\\\",\\\"0.07\\\",\\\"0.08\\\",\\\"0.09\\\",\\\"0.1\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"8588379458082123913\\\",\\\"id\\\":\\\"ob_06\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"8588379458082123913\\\",\\\"id\\\":\\\"ob_05\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"8588379458082123913\\\",\\\"id\\\":\\\"ob_06\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"8588379458082123913\\\",\\\"id\\\":\\\"ob_05\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\"],\"observables\":{\"changes\":{\"sync\":false,\"id\":\"ob_06\",\"value\":0},\"index\":{\"sync\":true,\"id\":\"ob_05\",\"value\":5}}},\"children\":[{\"props\":{\"className\":\"interact-flex-row interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact-flex-row-left\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact \",\"style\":{\"padding\":\"5px 10px 0px 10px\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"label\"},\"children\":[\"Td\"]}]},{\"props\":{\"className\":\"interact-flex-row-center\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"max\":10,\"min\":1,\"attributes\":{\"type\":\"range\",\"data-bind\":\"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\":\"horizontal\"},\"step\":1,\"className\":\"slider slider is-fullwidth\",\"style\":{}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"input\"},\"children\":[]}]},{\"props\":{\"className\":\"interact-flex-row-right\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"attributes\":{\"data-bind\":\"text: formatted_val\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"p\"},\"children\":[]}]}]}]}]},{\"props\":{},\"nodeType\":\"Scope\",\"type\":\"node\",\"instanceArgs\":{\"imports\":{\"data\":[],\"type\":\"async_block\"},\"id\":\"1566238113484050311\",\"handlers\":{},\"systemjs_options\":null,\"mount_callbacks\":[],\"observables\":{\"obs-node\":{\"sync\":false,\"id\":\"ob_10\",\"value\":{\"props\":{\"className\":\"interact-flex-row interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"setInnerHtml\":\"<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\"?>\\n<svg xmlns=\\\"http:\\/\\/www.w3.org\\/2000\\/svg\\\" xmlns:xlink=\\\"http:\\/\\/www.w3.org\\/1999\\/xlink\\\" width=\\\"600\\\" height=\\\"400\\\" viewBox=\\\"0 0 2400 1600\\\">\\n<defs>\\n  <clipPath id=\\\"clip1500\\\">\\n    <rect x=\\\"0\\\" y=\\\"0\\\" width=\\\"2400\\\" height=\\\"1600\\\"\\/>\\n  <\\/clipPath>\\n<\\/defs>\\n<path clip-path=\\\"url(#clip1500)\\\" d=\\\"\\nM0 1600 L2400 1600 L2400 0 L0 0  Z\\n  \\\" fill=\\\"#ffffff\\\" fill-rule=\\\"evenodd\\\" fill-opacity=\\\"1\\\"\\/>\\n<defs>\\n  <clipPath id=\\\"clip1501\\\">\\n    <rect x=\\\"480\\\" y=\\\"0\\\" width=\\\"1681\\\" height=\\\"1600\\\"\\/>\\n  <\\/clipPath>\\n<\\/defs>\\n<path clip-path=\\\"url(#clip1500)\\\" d=\\\"\\nM215.754 1412.31 L2352.76 1412.31 L2352.76 121.675 L215.754 121.675  Z\\n  \\\" fill=\\\"#ffffff\\\" fill-rule=\\\"evenodd\\\" fill-opacity=\\\"1\\\"\\/>\\n<defs>\\n  <clipPath id=\\\"clip1502\\\">\\n    <rect x=\\\"215\\\" y=\\\"121\\\" width=\\\"2138\\\" height=\\\"1292\\\"\\/>\\n  <\\/clipPath>\\n<\\/defs>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  276.235,1412.31 276.235,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  478.531,1412.31 478.531,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  596.867,1412.31 596.867,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  680.828,1412.31 680.828,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  745.952,1412.31 745.952,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  799.163,1412.31 799.163,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  844.152,1412.31 844.152,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  883.124,1412.31 883.124,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  917.499,1412.31 917.499,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  948.248,1412.31 948.248,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1150.54,1412.31 1150.54,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1268.88,1412.31 1268.88,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1352.84,1412.31 1352.84,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1417.97,1412.31 1417.97,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1471.18,1412.31 1471.18,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1516.17,1412.31 1516.17,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1555.14,1412.31 1555.14,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1589.51,1412.31 1589.51,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1620.26,1412.31 1620.26,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1822.56,1412.31 1822.56,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1940.89,1412.31 1940.89,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2024.85,1412.31 2024.85,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2089.98,1412.31 2089.98,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2143.19,1412.31 2143.19,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2188.18,1412.31 2188.18,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2227.15,1412.31 2227.15,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2261.53,1412.31 2261.53,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2292.27,1412.31 2292.27,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,1399.37 2352.76,1399.37 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,1348.53 2352.76,1348.53 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,1297.7 2352.76,1297.7 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,1246.86 2352.76,1246.86 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,1196.02 2352.76,1196.02 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,1145.19 2352.76,1145.19 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,1094.35 2352.76,1094.35 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,1043.51 2352.76,1043.51 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,992.679 2352.76,992.679 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,941.843 2352.76,941.843 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,891.007 2352.76,891.007 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,840.171 2352.76,840.171 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,789.335 2352.76,789.335 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,738.498 2352.76,738.498 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,687.662 2352.76,687.662 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,636.826 2352.76,636.826 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,585.99 2352.76,585.99 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,535.154 2352.76,535.154 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,484.318 2352.76,484.318 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,433.482 2352.76,433.482 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  215.754,382.646 2352.76,382.646 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1412.31 2352.76,1412.31 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1412.31 215.754,121.675 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  276.235,1412.31 276.235,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  478.531,1412.31 478.531,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  596.867,1412.31 596.867,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  680.828,1412.31 680.828,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  745.952,1412.31 745.952,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  799.163,1412.31 799.163,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  844.152,1412.31 844.152,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  883.124,1412.31 883.124,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  917.499,1412.31 917.499,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  948.248,1412.31 948.248,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1150.54,1412.31 1150.54,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1268.88,1412.31 1268.88,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1352.84,1412.31 1352.84,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1417.97,1412.31 1417.97,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1471.18,1412.31 1471.18,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1516.17,1412.31 1516.17,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1555.14,1412.31 1555.14,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1589.51,1412.31 1589.51,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1620.26,1412.31 1620.26,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1822.56,1412.31 1822.56,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1940.89,1412.31 1940.89,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2024.85,1412.31 2024.85,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2089.98,1412.31 2089.98,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2143.19,1412.31 2143.19,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2188.18,1412.31 2188.18,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2227.15,1412.31 2227.15,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2261.53,1412.31 2261.53,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2292.27,1412.31 2292.27,1396.82 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1399.37 241.398,1399.37 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1348.53 241.398,1348.53 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1297.7 241.398,1297.7 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1246.86 241.398,1246.86 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1196.02 241.398,1196.02 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1145.19 241.398,1145.19 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1094.35 241.398,1094.35 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,1043.51 241.398,1043.51 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,992.679 241.398,992.679 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,941.843 241.398,941.843 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,891.007 241.398,891.007 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,840.171 241.398,840.171 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,789.335 241.398,789.335 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,738.498 241.398,738.498 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,687.662 241.398,687.662 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,636.826 241.398,636.826 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,585.99 241.398,585.99 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,535.154 241.398,535.154 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,484.318 241.398,484.318 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,433.482 241.398,433.482 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  215.754,382.646 241.398,382.646 \\n  \\\"\\/>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 238.601, 1487.32)\\\" x=\\\"238.601\\\" y=\\\"1487.32\\\">10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 292.125, 1459.91)\\\" x=\\\"292.125\\\" y=\\\"1459.91\\\">0<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(478, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(596, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(680, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(745, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(799, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(844, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(883, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(917, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 910.614, 1487.32)\\\" x=\\\"910.614\\\" y=\\\"1487.32\\\">10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 964.139, 1459.91)\\\" x=\\\"964.139\\\" y=\\\"1459.91\\\">1<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1150, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1268, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1352, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1417, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1471, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1516, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1555, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1589, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 1582.63, 1487.32)\\\" x=\\\"1582.63\\\" y=\\\"1487.32\\\">10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 1636.15, 1459.91)\\\" x=\\\"1636.15\\\" y=\\\"1459.91\\\">2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1822, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(1940, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(2024, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(2089, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(2143, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(2188, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(2227, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"1\\\" height=\\\"1\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQImWP4\\/\\/8\\/AwAI\\/AL+hc2r\\nNAAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(2261, 1423)\\\"\\/>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 2254.64, 1487.32)\\\" x=\\\"2254.64\\\" y=\\\"1487.32\\\">10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 2308.16, 1459.91)\\\" x=\\\"2308.16\\\" y=\\\"1459.91\\\">3<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 1416.87)\\\" x=\\\"191.754\\\" y=\\\"1416.87\\\">0.0<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 1366.03)\\\" x=\\\"191.754\\\" y=\\\"1366.03\\\">0.2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 1315.2)\\\" x=\\\"191.754\\\" y=\\\"1315.2\\\">0.4<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 1264.36)\\\" x=\\\"191.754\\\" y=\\\"1264.36\\\">0.6<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 1213.52)\\\" x=\\\"191.754\\\" y=\\\"1213.52\\\">0.8<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 1162.69)\\\" x=\\\"191.754\\\" y=\\\"1162.69\\\">1.0<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 1111.85)\\\" x=\\\"191.754\\\" y=\\\"1111.85\\\">1.2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 1061.01)\\\" x=\\\"191.754\\\" y=\\\"1061.01\\\">1.4<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 1010.18)\\\" x=\\\"191.754\\\" y=\\\"1010.18\\\">1.6<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 959.343)\\\" x=\\\"191.754\\\" y=\\\"959.343\\\">1.8<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 908.507)\\\" x=\\\"191.754\\\" y=\\\"908.507\\\">2.0<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 857.671)\\\" x=\\\"191.754\\\" y=\\\"857.671\\\">2.2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 806.835)\\\" x=\\\"191.754\\\" y=\\\"806.835\\\">2.4<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 755.998)\\\" x=\\\"191.754\\\" y=\\\"755.998\\\">2.6<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 705.162)\\\" x=\\\"191.754\\\" y=\\\"705.162\\\">2.8<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 654.326)\\\" x=\\\"191.754\\\" y=\\\"654.326\\\">3.0<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 603.49)\\\" x=\\\"191.754\\\" y=\\\"603.49\\\">3.2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 552.654)\\\" x=\\\"191.754\\\" y=\\\"552.654\\\">3.4<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 501.818)\\\" x=\\\"191.754\\\" y=\\\"501.818\\\">3.6<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 450.982)\\\" x=\\\"191.754\\\" y=\\\"450.982\\\">3.8<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:end;\\\" transform=\\\"rotate(0, 191.754, 400.146)\\\" x=\\\"191.754\\\" y=\\\"400.146\\\">4.0<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:84px; text-anchor:middle;\\\" transform=\\\"rotate(0, 1284.25, 73.2)\\\" x=\\\"1284.25\\\" y=\\\"73.2\\\">Sensitivity<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\\\" transform=\\\"rotate(0, 1284.25, 1566.14)\\\" x=\\\"1284.25\\\" y=\\\"1566.14\\\">Frequency (rad\\/s)<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\\\" transform=\\\"rotate(-90, 89.2861, 766.992)\\\" x=\\\"89.2861\\\" y=\\\"766.992\\\">Magnitude <\\/text>\\n<\\/g>\\n<polyline clip-path=\\\"url(#clip1502)\\\" style=\\\"stroke:#cc1414; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  276.235,158.202 286.366,160.725 296.497,163.41 306.628,166.269 316.759,169.309 326.89,172.543 337.02,175.979 347.151,179.629 357.282,183.503 367.413,187.614 \\n  377.544,191.971 387.675,196.587 397.805,201.474 407.936,206.643 418.067,212.106 428.198,217.874 438.329,223.961 448.46,230.375 458.591,237.13 468.721,244.234 \\n  478.852,251.699 488.983,259.532 499.114,267.743 509.245,276.338 519.376,285.325 529.507,294.708 539.637,304.491 549.768,314.677 559.899,325.265 570.03,336.255 \\n  580.161,347.644 590.292,359.428 600.423,371.599 610.553,384.148 620.684,397.066 630.815,410.339 640.946,423.952 651.077,437.89 661.208,452.131 671.338,466.658 \\n  681.469,481.446 691.6,496.473 701.731,511.713 711.862,527.139 721.993,542.725 732.124,558.442 742.254,574.261 752.385,590.153 762.516,606.088 772.647,622.036 \\n  782.778,637.969 792.909,653.858 803.04,669.673 813.17,685.388 823.301,700.975 833.432,716.409 843.563,731.665 853.694,746.719 863.825,761.549 873.956,776.134 \\n  884.086,790.454 894.217,804.49 904.348,818.226 914.479,831.645 924.61,844.732 934.741,857.475 944.871,869.86 955.002,881.876 965.133,893.513 975.264,904.761 \\n  985.395,915.611 995.526,926.056 1005.66,936.087 1015.79,945.697 1025.92,954.881 1036.05,963.631 1046.18,971.943 1056.31,979.81 1066.44,987.226 1076.57,994.186 \\n  1086.7,1000.68 1096.83,1006.72 1106.97,1012.28 1117.1,1017.36 1127.23,1021.97 1137.36,1026.09 1147.49,1029.74 1157.62,1032.9 1167.75,1035.59 1177.88,1037.82 \\n  1188.01,1039.6 1198.14,1040.97 1208.27,1041.98 1218.4,1042.68 1228.54,1043.17 1238.67,1043.55 1248.8,1043.99 1258.93,1044.68 1269.06,1045.85 1279.19,1047.79 \\n  1289.32,1050.8 1299.45,1055.17 1309.58,1061.2 1319.71,1069.07 1329.84,1078.86 1339.97,1090.51 1350.11,1103.8 1360.24,1118.39 1370.37,1133.85 1380.5,1149.74 \\n  1390.63,1165.65 1400.76,1181.22 1410.89,1196.19 1421.02,1210.37 1431.15,1223.66 1441.28,1235.99 1451.41,1247.37 1461.54,1257.81 1471.68,1267.37 1481.81,1276.1 \\n  1491.94,1284.06 1502.07,1291.31 1512.2,1297.92 1522.33,1303.95 1532.46,1309.45 1542.59,1314.48 1552.72,1319.07 1562.85,1323.28 1572.98,1327.13 1583.12,1330.67 \\n  1593.25,1333.92 1603.38,1336.9 1613.51,1339.66 1623.64,1342.2 1633.77,1344.54 1643.9,1346.71 1654.03,1348.72 1664.16,1350.57 1674.29,1352.3 1684.42,1353.9 \\n  1694.55,1355.38 1704.69,1356.76 1714.82,1358.05 1724.95,1359.25 1735.08,1360.36 1745.21,1361.4 1755.34,1362.37 1765.47,1363.27 1775.6,1364.11 1785.73,1364.9 \\n  1795.86,1365.64 1805.99,1366.32 1816.12,1366.97 1826.26,1367.57 1836.39,1368.13 1846.52,1368.65 1856.65,1369.14 1866.78,1369.6 1876.91,1370.03 1887.04,1370.43 \\n  1897.17,1370.81 1907.3,1371.16 1917.43,1371.48 1927.56,1371.79 1937.69,1372.08 1947.83,1372.34 1957.96,1372.59 1968.09,1372.83 1978.22,1373.05 1988.35,1373.25 \\n  1998.48,1373.44 2008.61,1373.62 2018.74,1373.79 2028.87,1373.95 2039,1374.09 2049.13,1374.23 2059.27,1374.36 2069.4,1374.47 2079.53,1374.59 2089.66,1374.69 \\n  2099.79,1374.79 2109.92,1374.88 2120.05,1374.96 2130.18,1375.04 2140.31,1375.11 2150.44,1375.18 2160.57,1375.25 2170.7,1375.31 2180.84,1375.36 2190.97,1375.42 \\n  2201.1,1375.46 2211.23,1375.51 2221.36,1375.55 2231.49,1375.59 2241.62,1375.63 2251.75,1375.66 2261.88,1375.7 2272.01,1375.73 2282.14,1375.75 2292.27,1375.78 \\n  \\n  \\\"\\/>\\n<path clip-path=\\\"url(#clip1500)\\\" d=\\\"\\nM1989.76 326.155 L2280.76 326.155 L2280.76 205.195 L1989.76 205.195  Z\\n  \\\" fill=\\\"#ffffff\\\" fill-rule=\\\"evenodd\\\" fill-opacity=\\\"1\\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1989.76,326.155 2280.76,326.155 2280.76,205.195 1989.76,205.195 1989.76,326.155 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip1500)\\\" style=\\\"stroke:#cc1414; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2013.76,265.675 2157.76,265.675 \\n  \\\"\\/>\\n<g clip-path=\\\"url(#clip1500)\\\">\\n<image width=\\\"51\\\" height=\\\"41\\\" xlink:href=\\\"data:image\\/png;base64,\\niVBORw0KGgoAAAANSUhEUgAAADMAAAApCAYAAACY7BHXAAADfElEQVRogd1Z7Y2jMBAdohRgU4Kz\\nFUALbAdmSyBbgZMSUgJJCWgrYLcEJxUAJTh08O7HHQhMPkgwudONNFJEyNhv\\/ObL8QCQazmfz+Cc\\ne84N35HFVAPf39+I4xhhGIJzDs\\/z4Ps+eZ4HzjnW6zXKsrzqsc1mgziO3XgUwMOqtUaSJGCMgYhA\\nRBBCQEoJpRTSNEWaplBKQQgBIkKSJLDt7HY7EBF2u93gu2f0oZeNMUiSpAXQbFJrfXMzWZaBMYYg\\nCNB91ti493vnYNI0HYAwxozeRFEUYIwhiiLked6z5QLIaDBSynZhxhjyPH9qAzYIIkIURa8BY4xB\\nEAS9uHjkNC5pFEU9MK7i5SaYhhYugVw6HVfxchNMk4UaarkA0i46Q7xcBWNTIcsyp4s2jupmt1nA\\nKKV6QKSUThfsOkspNR8YrfUg27ikV6NNdnw2K44C081cc3jOPhnXdtsP3Yo856k0TnMdLwBo2fRo\\n2+2217NFUURzdb5JkpDv++4N40qsuM5gr1AChhmMZuDzy8B0Kz3NlI5foYvj8Yi6rnvUi6LIPZ8d\\nSVmW2O\\/3l4e5S1nMZb\\/kUrXWbb946fulMWYAMAzDl8\\/v16QsS5xOJzocDvTz83Pz3WVVVb0HQohJ\\ni5\\/P59Hz\\/K3Uv9\\/v8fn5SUREjDH6+PigIAjodDpdN9gdvGjCsFQUxYCu9\\/RW4TTGoCiKXuHu7vUi\\nzezixRgb69ierFYr78+sQnVdkzGGGnp0JQgC2m63xBi7yQLOucc5f2gPy6m06sr7+\\/uANofDoUe7\\nLMtotVrNEpMLG4wdQ1PEvi8TQswGhIhoYdcUu+ZMETv7zF2\\/FpxzLwiC9kFVVQ9lpFvyajAEDC8Z\\n0jR1UjTtNmnqSHEvm7UfuoMZY2wyGNtBQojJNu+BaS\\/OsyxrT6uua9psNpOo1hS8Rl7S73WR2X3a\\nsxd0jQe7NHMxH42m2TVAUsrRXNdaQwgBxhi01ujacjGCPwwG+N2a2JcbSZIgz\\/PepowxyPMcSqn2\\nfftCXUrpbN5\\/CkyjeZ7D7t0uqRACSikURXFxkWvPXYPxgHFxfjweUVVV2yEIIdr+as6q3pU4jvH1\\n9UVERAAGay4Hv7giYRh6YRg63Jp7mfyf5r8k\\/xWY0TT7G9J03XVdk9a61+ut12tIKcn3fWKMke\\/7\\n4xPAq6UsS7y9vY1+XylFvwBZDw9vFy4ANwAAAABJRU5ErkJggg==\\n\\\" transform=\\\"translate(2182, 245)\\\"\\/>\\n<\\/g>\\n<\\/svg>\\n\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[]}]}}}},\"children\":[{\"props\":{},\"nodeType\":\"ObservableNode\",\"type\":\"node\",\"instanceArgs\":{\"id\":\"ob_10\",\"name\":\"obs-node\"},\"children\":[]}]}]},\n",
+       "            window,\n",
+       "        );\n",
+       "    } else {\n",
+       "        document\n",
+       "            .querySelector('[data-webio-mountpoint=\"1020870403091686237\"]')\n",
+       "            .innerHTML = (\n",
+       "                '<div style=\"padding: 1em; background-color: #f8d6da; border: 1px solid #f5c6cb\">' +\n",
+       "                '<p><strong>WebIO not detected.</strong></p>' +\n",
+       "                '<p>Please read ' +\n",
+       "                '<a href=\"https://juliagizmos.github.io/WebIO.jl/latest/troubleshooting/not-detected/\" target=\"_blank\">the troubleshooting guide</a> ' +\n",
+       "                'for more information on how to resolve this issue.</p>' +\n",
+       "                '<p><a href=\"https://juliagizmos.github.io/WebIO.jl/latest/troubleshooting/not-detected/\" target=\"_blank\">https://juliagizmos.github.io/WebIO.jl/latest/troubleshooting/not-detected/</a></p>' +\n",
+       "                '</div>'\n",
+       "            );\n",
+       "    }\n",
+       "    </script>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Scope(Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :label), Any[\"Kp\"], Dict{Symbol,Any}(:className => \"interact \",:style => Dict{Any,Any}(:padding => \"5px 10px 0px 10px\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-left\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :input), Any[], Dict{Symbol,Any}(:max => 35,:min => 1,:attributes => Dict{Any,Any}(:type => \"range\",Symbol(\"data-bind\") => \"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\" => \"horizontal\"),:step => 1,:className => \"slider slider is-fullwidth\",:style => Dict{Any,Any}()))], Dict{Symbol,Any}(:className => \"interact-flex-row-center\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :p), Any[], Dict{Symbol,Any}(:attributes => Dict(\"data-bind\" => \"text: formatted_val\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-right\"))], Dict{Symbol,Any}(:className => \"interact-flex-row interact-widget\")), Dict{String,Tuple{Observables.AbstractObservable,Union{Nothing, Bool}}}(\"changes\" => (Observable{Int64} with 1 listeners. Value:\n",
+       "0, nothing),\"index\" => (Observable{Any} with 2 listeners. Value:\n",
+       "18, nothing)), Set(String[]), nothing, Asset[Asset(\"js\", \"knockout\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout.js\"), Asset(\"js\", \"knockout_punches\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout_punches.js\"), Asset(\"js\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/all.js\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/style.css\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/Interact/SbgIk/src/../assets/bulma_confined.min.css\")], Dict{Any,Any}(\"changes\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\")],\"index\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\")]), WebIO.ConnectionPool(Channel{Any}(sz_max:32,sz_curr:0), Set(AbstractConnection[]), Base.GenericCondition{Base.AlwaysLockedST}(Base.InvasiveLinkedList{Task}(Task (runnable) @0x00007f3952c09600, Task (runnable) @0x00007f3952c09600), Base.AlwaysLockedST(1))), WebIO.JSString[WebIO.JSString(\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"3.0\\\",\\\"3.5\\\",\\\"4.0\\\",\\\"4.5\\\",\\\"5.0\\\",\\\"5.5\\\",\\\"6.0\\\",\\\"6.5\\\",\\\"7.0\\\",\\\"7.5\\\",\\\"8.0\\\",\\\"8.5\\\",\\\"9.0\\\",\\\"9.5\\\",\\\"10.0\\\",\\\"10.5\\\",\\\"11.0\\\",\\\"11.5\\\",\\\"12.0\\\",\\\"12.5\\\",\\\"13.0\\\",\\\"13.5\\\",\\\"14.0\\\",\\\"14.5\\\",\\\"15.0\\\",\\\"15.5\\\",\\\"16.0\\\",\\\"16.5\\\",\\\"17.0\\\",\\\"17.5\\\",\\\"18.0\\\",\\\"18.5\\\",\\\"19.0\\\",\\\"19.5\\\",\\\"20.0\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"18347416247943877564\\\",\\\"id\\\":\\\"ob_03\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"18347416247943877564\\\",\\\"id\\\":\\\"ob_02\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"18347416247943877564\\\",\\\"id\\\":\\\"ob_03\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"18347416247943877564\\\",\\\"id\\\":\\\"ob_02\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\")])], Dict{Symbol,Any}(:className => \"field interact-widget\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Scope(Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :label), Any[\"Td\"], Dict{Symbol,Any}(:className => \"interact \",:style => Dict{Any,Any}(:padding => \"5px 10px 0px 10px\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-left\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :input), Any[], Dict{Symbol,Any}(:max => 10,:min => 1,:attributes => Dict{Any,Any}(:type => \"range\",Symbol(\"data-bind\") => \"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\" => \"horizontal\"),:step => 1,:className => \"slider slider is-fullwidth\",:style => Dict{Any,Any}()))], Dict{Symbol,Any}(:className => \"interact-flex-row-center\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :p), Any[], Dict{Symbol,Any}(:attributes => Dict(\"data-bind\" => \"text: formatted_val\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-right\"))], Dict{Symbol,Any}(:className => \"interact-flex-row interact-widget\")), Dict{String,Tuple{Observables.AbstractObservable,Union{Nothing, Bool}}}(\"changes\" => (Observable{Int64} with 1 listeners. Value:\n",
+       "0, nothing),\"index\" => (Observable{Any} with 2 listeners. Value:\n",
+       "5, nothing)), Set(String[]), nothing, Asset[Asset(\"js\", \"knockout\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout.js\"), Asset(\"js\", \"knockout_punches\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout_punches.js\"), Asset(\"js\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/all.js\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/style.css\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/Interact/SbgIk/src/../assets/bulma_confined.min.css\")], Dict{Any,Any}(\"changes\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\")],\"index\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\")]), WebIO.ConnectionPool(Channel{Any}(sz_max:32,sz_curr:0), Set(AbstractConnection[]), Base.GenericCondition{Base.AlwaysLockedST}(Base.InvasiveLinkedList{Task}(Task (runnable) @0x00007f395379bd00, Task (runnable) @0x00007f395379bd00), Base.AlwaysLockedST(1))), WebIO.JSString[WebIO.JSString(\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"0.01\\\",\\\"0.02\\\",\\\"0.03\\\",\\\"0.04\\\",\\\"0.05\\\",\\\"0.06\\\",\\\"0.07\\\",\\\"0.08\\\",\\\"0.09\\\",\\\"0.1\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"8588379458082123913\\\",\\\"id\\\":\\\"ob_06\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"8588379458082123913\\\",\\\"id\\\":\\\"ob_05\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"8588379458082123913\\\",\\\"id\\\":\\\"ob_06\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"8588379458082123913\\\",\\\"id\\\":\\\"ob_05\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\")])], Dict{Symbol,Any}(:className => \"field interact-widget\")), Observable{Any} with 0 listeners. Value:\n",
+       "Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Plot{Plots.GRBackend() n=1}], Dict{Symbol,Any}(:className => \"interact-flex-row interact-widget\"))], Dict{Symbol,Any}())"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {
+      "application/vnd.webio.node+json": {
+       "kernelId": "5c66a939-fe49-49f0-b4f0-78a0c78f0033"
+      }
+     },
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
+    "using WebIO\n",
     "using Interact\n",
     "s = tf(\"s\")\n",
     "ui = @manipulate for Kp = 3:.5:20, Td = 0.01:.01:0.1\n",
@@ -419,20 +1057,684 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.webio.node+json": {
+       "children": [
+        {
+         "children": [
+          {
+           "children": [
+            {
+             "children": [
+              {
+               "children": [
+                {
+                 "children": [
+                  "Kp"
+                 ],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "label"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "className": "interact ",
+                  "style": {
+                   "padding": "5px 10px 0px 10px"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-left"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "input"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}",
+                   "orient": "horizontal",
+                   "type": "range"
+                  },
+                  "className": "slider slider is-fullwidth",
+                  "max": 33,
+                  "min": 1,
+                  "step": 1,
+                  "style": {}
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-center"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "p"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "text: formatted_val"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-right"
+               },
+               "type": "node"
+              }
+             ],
+             "instanceArgs": {
+              "namespace": "html",
+              "tag": "div"
+             },
+             "nodeType": "DOM",
+             "props": {
+              "className": "interact-flex-row interact-widget"
+             },
+             "type": "node"
+            }
+           ],
+           "instanceArgs": {
+            "handlers": {
+             "changes": [
+              "(function (val){return (val!=this.model[\"changes\"]()) ? (this.valueFromJulia[\"changes\"]=true, this.model[\"changes\"](val)) : undefined})"
+             ],
+             "index": [
+              "(function (val){return (val!=this.model[\"index\"]()) ? (this.valueFromJulia[\"index\"]=true, this.model[\"index\"](val)) : undefined})"
+             ]
+            },
+            "id": "5522547382221971813",
+            "imports": {
+             "data": [
+              {
+               "name": "knockout",
+               "type": "js",
+               "url": "/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js"
+              },
+              {
+               "name": "knockout_punches",
+               "type": "js",
+               "url": "/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js"
+              },
+              {
+               "name": null,
+               "type": "js",
+               "url": "/assetserver/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css"
+              }
+             ],
+             "type": "async_block"
+            },
+            "mount_callbacks": [
+             "function () {\n    var handler = (function (ko, koPunches) {\n    ko.punches.enableAll();\n    ko.bindingHandlers.numericValue = {\n        init: function(element, valueAccessor, allBindings, data, context) {\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\n            stringified.subscribe(function(value) {\n                var val = parseFloat(value);\n                if (!isNaN(val)) {\n                    valueAccessor()(val);\n                }\n            });\n            valueAccessor().subscribe(function(value) {\n                var str = JSON.stringify(value);\n                if ((str == \"0\") && ([\"-0\", \"-0.\"].indexOf(stringified()) >= 0))\n                     return;\n                 if ([\"null\", \"\"].indexOf(str) >= 0)\n                     return;\n                stringified(str);\n            });\n            ko.applyBindingsToNode(\n                element,\n                {\n                    value: stringified,\n                    valueUpdate: allBindings.get('valueUpdate'),\n                },\n                context,\n            );\n        }\n    };\n    var json_data = {\"formatted_vals\":[\"7.0\",\"7.5\",\"8.0\",\"8.5\",\"9.0\",\"9.5\",\"10.0\",\"10.5\",\"11.0\",\"11.5\",\"12.0\",\"12.5\",\"13.0\",\"13.5\",\"14.0\",\"14.5\",\"15.0\",\"15.5\",\"16.0\",\"16.5\",\"17.0\",\"17.5\",\"18.0\",\"18.5\",\"19.0\",\"19.5\",\"20.0\",\"20.5\",\"21.0\",\"21.5\",\"22.0\",\"22.5\",\"23.0\"],\"changes\":WebIO.getval({\"name\":\"changes\",\"scope\":\"5522547382221971813\",\"id\":\"ob_15\",\"type\":\"observable\"}),\"index\":WebIO.getval({\"name\":\"index\",\"scope\":\"5522547382221971813\",\"id\":\"ob_14\",\"type\":\"observable\"})};\n    var self = this;\n    function AppViewModel() {\n        for (var key in json_data) {\n            var el = json_data[key];\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\n        }\n        \n        [this[\"formatted_val\"]=ko.computed(    function(){\n        return this.formatted_vals()[parseInt(this.index())-(1)];\n    }\n,this)]\n        [this[\"changes\"].subscribe((function (val){!(this.valueFromJulia[\"changes\"]) ? (WebIO.setval({\"name\":\"changes\",\"scope\":\"5522547382221971813\",\"id\":\"ob_15\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"changes\"]=false}),self),this[\"index\"].subscribe((function (val){!(this.valueFromJulia[\"index\"]) ? (WebIO.setval({\"name\":\"index\",\"scope\":\"5522547382221971813\",\"id\":\"ob_14\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"index\"]=false}),self)]\n        \n    }\n    self.model = new AppViewModel();\n    self.valueFromJulia = {};\n    for (var key in json_data) {\n        self.valueFromJulia[key] = false;\n    }\n    ko.applyBindings(self.model, self.dom);\n}\n);\n    (WebIO.importBlock({\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"}],\"type\":\"async_block\"})).then((imports) => handler.apply(this, imports));\n}\n"
+            ],
+            "observables": {
+             "changes": {
+              "id": "ob_15",
+              "sync": false,
+              "value": 0
+             },
+             "index": {
+              "id": "ob_14",
+              "sync": true,
+              "value": 17
+             }
+            },
+            "systemjs_options": null
+           },
+           "nodeType": "Scope",
+           "props": {},
+           "type": "node"
+          }
+         ],
+         "instanceArgs": {
+          "namespace": "html",
+          "tag": "div"
+         },
+         "nodeType": "DOM",
+         "props": {
+          "className": "field interact-widget"
+         },
+         "type": "node"
+        },
+        {
+         "children": [
+          {
+           "children": [
+            {
+             "children": [
+              {
+               "children": [
+                {
+                 "children": [
+                  "Td"
+                 ],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "label"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "className": "interact ",
+                  "style": {
+                   "padding": "5px 10px 0px 10px"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-left"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "input"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}",
+                   "orient": "horizontal",
+                   "type": "range"
+                  },
+                  "className": "slider slider is-fullwidth",
+                  "max": 10,
+                  "min": 1,
+                  "step": 1,
+                  "style": {}
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-center"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "p"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "text: formatted_val"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-right"
+               },
+               "type": "node"
+              }
+             ],
+             "instanceArgs": {
+              "namespace": "html",
+              "tag": "div"
+             },
+             "nodeType": "DOM",
+             "props": {
+              "className": "interact-flex-row interact-widget"
+             },
+             "type": "node"
+            }
+           ],
+           "instanceArgs": {
+            "handlers": {
+             "changes": [
+              "(function (val){return (val!=this.model[\"changes\"]()) ? (this.valueFromJulia[\"changes\"]=true, this.model[\"changes\"](val)) : undefined})"
+             ],
+             "index": [
+              "(function (val){return (val!=this.model[\"index\"]()) ? (this.valueFromJulia[\"index\"]=true, this.model[\"index\"](val)) : undefined})"
+             ]
+            },
+            "id": "5835400797425742633",
+            "imports": {
+             "data": [
+              {
+               "name": "knockout",
+               "type": "js",
+               "url": "/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js"
+              },
+              {
+               "name": "knockout_punches",
+               "type": "js",
+               "url": "/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js"
+              },
+              {
+               "name": null,
+               "type": "js",
+               "url": "/assetserver/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css"
+              }
+             ],
+             "type": "async_block"
+            },
+            "mount_callbacks": [
+             "function () {\n    var handler = (function (ko, koPunches) {\n    ko.punches.enableAll();\n    ko.bindingHandlers.numericValue = {\n        init: function(element, valueAccessor, allBindings, data, context) {\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\n            stringified.subscribe(function(value) {\n                var val = parseFloat(value);\n                if (!isNaN(val)) {\n                    valueAccessor()(val);\n                }\n            });\n            valueAccessor().subscribe(function(value) {\n                var str = JSON.stringify(value);\n                if ((str == \"0\") && ([\"-0\", \"-0.\"].indexOf(stringified()) >= 0))\n                     return;\n                 if ([\"null\", \"\"].indexOf(str) >= 0)\n                     return;\n                stringified(str);\n            });\n            ko.applyBindingsToNode(\n                element,\n                {\n                    value: stringified,\n                    valueUpdate: allBindings.get('valueUpdate'),\n                },\n                context,\n            );\n        }\n    };\n    var json_data = {\"formatted_vals\":[\"0.01\",\"0.02\",\"0.03\",\"0.04\",\"0.05\",\"0.06\",\"0.07\",\"0.08\",\"0.09\",\"0.1\"],\"changes\":WebIO.getval({\"name\":\"changes\",\"scope\":\"5835400797425742633\",\"id\":\"ob_18\",\"type\":\"observable\"}),\"index\":WebIO.getval({\"name\":\"index\",\"scope\":\"5835400797425742633\",\"id\":\"ob_17\",\"type\":\"observable\"})};\n    var self = this;\n    function AppViewModel() {\n        for (var key in json_data) {\n            var el = json_data[key];\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\n        }\n        \n        [this[\"formatted_val\"]=ko.computed(    function(){\n        return this.formatted_vals()[parseInt(this.index())-(1)];\n    }\n,this)]\n        [this[\"changes\"].subscribe((function (val){!(this.valueFromJulia[\"changes\"]) ? (WebIO.setval({\"name\":\"changes\",\"scope\":\"5835400797425742633\",\"id\":\"ob_18\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"changes\"]=false}),self),this[\"index\"].subscribe((function (val){!(this.valueFromJulia[\"index\"]) ? (WebIO.setval({\"name\":\"index\",\"scope\":\"5835400797425742633\",\"id\":\"ob_17\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"index\"]=false}),self)]\n        \n    }\n    self.model = new AppViewModel();\n    self.valueFromJulia = {};\n    for (var key in json_data) {\n        self.valueFromJulia[key] = false;\n    }\n    ko.applyBindings(self.model, self.dom);\n}\n);\n    (WebIO.importBlock({\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"}],\"type\":\"async_block\"})).then((imports) => handler.apply(this, imports));\n}\n"
+            ],
+            "observables": {
+             "changes": {
+              "id": "ob_18",
+              "sync": false,
+              "value": 0
+             },
+             "index": {
+              "id": "ob_17",
+              "sync": true,
+              "value": 5
+             }
+            },
+            "systemjs_options": null
+           },
+           "nodeType": "Scope",
+           "props": {},
+           "type": "node"
+          }
+         ],
+         "instanceArgs": {
+          "namespace": "html",
+          "tag": "div"
+         },
+         "nodeType": "DOM",
+         "props": {
+          "className": "field interact-widget"
+         },
+         "type": "node"
+        },
+        {
+         "children": [
+          {
+           "children": [
+            {
+             "children": [
+              {
+               "children": [
+                {
+                 "children": [
+                  "d0"
+                 ],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "label"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "className": "interact ",
+                  "style": {
+                   "padding": "5px 10px 0px 10px"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-left"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "input"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}",
+                   "orient": "horizontal",
+                   "type": "range"
+                  },
+                  "className": "slider slider is-fullwidth",
+                  "max": 51,
+                  "min": 1,
+                  "step": 1,
+                  "style": {}
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-center"
+               },
+               "type": "node"
+              },
+              {
+               "children": [
+                {
+                 "children": [],
+                 "instanceArgs": {
+                  "namespace": "html",
+                  "tag": "p"
+                 },
+                 "nodeType": "DOM",
+                 "props": {
+                  "attributes": {
+                   "data-bind": "text: formatted_val"
+                  }
+                 },
+                 "type": "node"
+                }
+               ],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "className": "interact-flex-row-right"
+               },
+               "type": "node"
+              }
+             ],
+             "instanceArgs": {
+              "namespace": "html",
+              "tag": "div"
+             },
+             "nodeType": "DOM",
+             "props": {
+              "className": "interact-flex-row interact-widget"
+             },
+             "type": "node"
+            }
+           ],
+           "instanceArgs": {
+            "handlers": {
+             "changes": [
+              "(function (val){return (val!=this.model[\"changes\"]()) ? (this.valueFromJulia[\"changes\"]=true, this.model[\"changes\"](val)) : undefined})"
+             ],
+             "index": [
+              "(function (val){return (val!=this.model[\"index\"]()) ? (this.valueFromJulia[\"index\"]=true, this.model[\"index\"](val)) : undefined})"
+             ]
+            },
+            "id": "4044788257546097905",
+            "imports": {
+             "data": [
+              {
+               "name": "knockout",
+               "type": "js",
+               "url": "/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js"
+              },
+              {
+               "name": "knockout_punches",
+               "type": "js",
+               "url": "/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js"
+              },
+              {
+               "name": null,
+               "type": "js",
+               "url": "/assetserver/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css"
+              },
+              {
+               "name": null,
+               "type": "css",
+               "url": "/assetserver/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css"
+              }
+             ],
+             "type": "async_block"
+            },
+            "mount_callbacks": [
+             "function () {\n    var handler = (function (ko, koPunches) {\n    ko.punches.enableAll();\n    ko.bindingHandlers.numericValue = {\n        init: function(element, valueAccessor, allBindings, data, context) {\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\n            stringified.subscribe(function(value) {\n                var val = parseFloat(value);\n                if (!isNaN(val)) {\n                    valueAccessor()(val);\n                }\n            });\n            valueAccessor().subscribe(function(value) {\n                var str = JSON.stringify(value);\n                if ((str == \"0\") && ([\"-0\", \"-0.\"].indexOf(stringified()) >= 0))\n                     return;\n                 if ([\"null\", \"\"].indexOf(str) >= 0)\n                     return;\n                stringified(str);\n            });\n            ko.applyBindingsToNode(\n                element,\n                {\n                    value: stringified,\n                    valueUpdate: allBindings.get('valueUpdate'),\n                },\n                context,\n            );\n        }\n    };\n    var json_data = {\"formatted_vals\":[\"0.015\",\"0.0152\",\"0.0154\",\"0.0156\",\"0.0158\",\"0.016\",\"0.0162\",\"0.0164\",\"0.0166\",\"0.0168\",\"0.017\",\"0.0172\",\"0.0174\",\"0.0176\",\"0.0178\",\"0.018\",\"0.0182\",\"0.0184\",\"0.0186\",\"0.0188\",\"0.019\",\"0.0192\",\"0.0194\",\"0.0196\",\"0.0198\",\"0.02\",\"0.0202\",\"0.0204\",\"0.0206\",\"0.0208\",\"0.021\",\"0.0212\",\"0.0214\",\"0.0216\",\"0.0218\",\"0.022\",\"0.0222\",\"0.0224\",\"0.0226\",\"0.0228\",\"0.023\",\"0.0232\",\"0.0234\",\"0.0236\",\"0.0238\",\"0.024\",\"0.0242\",\"0.0244\",\"0.0246\",\"0.0248\",\"0.025\"],\"changes\":WebIO.getval({\"name\":\"changes\",\"scope\":\"4044788257546097905\",\"id\":\"ob_21\",\"type\":\"observable\"}),\"index\":WebIO.getval({\"name\":\"index\",\"scope\":\"4044788257546097905\",\"id\":\"ob_20\",\"type\":\"observable\"})};\n    var self = this;\n    function AppViewModel() {\n        for (var key in json_data) {\n            var el = json_data[key];\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\n        }\n        \n        [this[\"formatted_val\"]=ko.computed(    function(){\n        return this.formatted_vals()[parseInt(this.index())-(1)];\n    }\n,this)]\n        [this[\"changes\"].subscribe((function (val){!(this.valueFromJulia[\"changes\"]) ? (WebIO.setval({\"name\":\"changes\",\"scope\":\"4044788257546097905\",\"id\":\"ob_21\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"changes\"]=false}),self),this[\"index\"].subscribe((function (val){!(this.valueFromJulia[\"index\"]) ? (WebIO.setval({\"name\":\"index\",\"scope\":\"4044788257546097905\",\"id\":\"ob_20\",\"type\":\"observable\"},val)) : undefined; return this.valueFromJulia[\"index\"]=false}),self)]\n        \n    }\n    self.model = new AppViewModel();\n    self.valueFromJulia = {};\n    for (var key in json_data) {\n        self.valueFromJulia[key] = false;\n    }\n    ko.applyBindings(self.model, self.dom);\n}\n);\n    (WebIO.importBlock({\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"}],\"type\":\"async_block\"})).then((imports) => handler.apply(this, imports));\n}\n"
+            ],
+            "observables": {
+             "changes": {
+              "id": "ob_21",
+              "sync": false,
+              "value": 0
+             },
+             "index": {
+              "id": "ob_20",
+              "sync": true,
+              "value": 26
+             }
+            },
+            "systemjs_options": null
+           },
+           "nodeType": "Scope",
+           "props": {},
+           "type": "node"
+          }
+         ],
+         "instanceArgs": {
+          "namespace": "html",
+          "tag": "div"
+         },
+         "nodeType": "DOM",
+         "props": {
+          "className": "field interact-widget"
+         },
+         "type": "node"
+        },
+        {
+         "children": [
+          {
+           "children": [],
+           "instanceArgs": {
+            "id": "ob_27",
+            "name": "obs-node"
+           },
+           "nodeType": "ObservableNode",
+           "props": {},
+           "type": "node"
+          }
+         ],
+         "instanceArgs": {
+          "handlers": {},
+          "id": "4426861128510389198",
+          "imports": {
+           "data": [],
+           "type": "async_block"
+          },
+          "mount_callbacks": [],
+          "observables": {
+           "obs-node": {
+            "id": "ob_27",
+            "sync": false,
+            "value": {
+             "children": [
+              {
+               "children": [],
+               "instanceArgs": {
+                "namespace": "html",
+                "tag": "div"
+               },
+               "nodeType": "DOM",
+               "props": {
+                "setInnerHtml": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"700\" height=\"300\" viewBox=\"0 0 2800 1200\">\n<defs>\n  <clipPath id=\"clip2700\">\n    <rect x=\"0\" y=\"0\" width=\"2800\" height=\"1200\"/>\n  </clipPath>\n</defs>\n<path clip-path=\"url(#clip2700)\" d=\"\nM0 1200 L2800 1200 L2800 0 L0 0  Z\n  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n<defs>\n  <clipPath id=\"clip2701\">\n    <rect x=\"560\" y=\"0\" width=\"1961\" height=\"1200\"/>\n  </clipPath>\n</defs>\n<path clip-path=\"url(#clip2700)\" d=\"\nM500.561 1058.06 L1366.14 1058.06 L1366.14 47.2441 L500.561 47.2441  Z\n  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n<defs>\n  <clipPath id=\"clip2702\">\n    <rect x=\"500\" y=\"47\" width=\"867\" height=\"1012\"/>\n  </clipPath>\n</defs>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  525.058,1058.06 525.058,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  688.374,1058.06 688.374,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  851.691,1058.06 851.691,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1015.01,1058.06 1015.01,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1178.32,1058.06 1178.32,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1341.64,1058.06 1341.64,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  500.561,965.816 1366.14,965.816 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  500.561,774.904 1366.14,774.904 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  500.561,583.992 1366.14,583.992 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  500.561,393.079 1366.14,393.079 \n  \"/>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  500.561,202.167 1366.14,202.167 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  500.561,1058.06 1366.14,1058.06 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  500.561,1058.06 500.561,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  525.058,1058.06 525.058,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  688.374,1058.06 688.374,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  851.691,1058.06 851.691,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1015.01,1058.06 1015.01,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1178.32,1058.06 1178.32,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1341.64,1058.06 1341.64,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  500.561,965.816 510.948,965.816 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  500.561,774.904 510.948,774.904 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  500.561,583.992 510.948,583.992 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  500.561,393.079 510.948,393.079 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  500.561,202.167 510.948,202.167 \n  \"/>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 525.058, 1114.06)\" x=\"525.058\" y=\"1114.06\">0.0</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 688.374, 1114.06)\" x=\"688.374\" y=\"1114.06\">0.1</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 851.691, 1114.06)\" x=\"851.691\" y=\"1114.06\">0.2</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 1015.01, 1114.06)\" x=\"1015.01\" y=\"1114.06\">0.3</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 1178.32, 1114.06)\" x=\"1178.32\" y=\"1114.06\">0.4</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 1341.64, 1114.06)\" x=\"1341.64\" y=\"1114.06\">0.5</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 145.625, 989.544)\" x=\"145.625\" y=\"989.544\">2.000001×10</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 427.977, 962.134)\" x=\"427.977\" y=\"962.134\">-</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 450.816, 962.134)\" x=\"450.816\" y=\"962.134\">2</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 145.625, 798.632)\" x=\"145.625\" y=\"798.632\">2.000004×10</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 427.977, 771.221)\" x=\"427.977\" y=\"771.221\">-</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 450.816, 771.221)\" x=\"450.816\" y=\"771.221\">2</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 145.625, 607.719)\" x=\"145.625\" y=\"607.719\">2.000007×10</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 427.977, 580.309)\" x=\"427.977\" y=\"580.309\">-</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 450.816, 580.309)\" x=\"450.816\" y=\"580.309\">2</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 145.625, 416.807)\" x=\"145.625\" y=\"416.807\">2.000010×10</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 427.977, 389.396)\" x=\"427.977\" y=\"389.396\">-</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 450.816, 389.396)\" x=\"450.816\" y=\"389.396\">2</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 145.625, 225.894)\" x=\"145.625\" y=\"225.894\">2.000013×10</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 427.977, 198.484)\" x=\"427.977\" y=\"198.484\">-</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 450.816, 198.484)\" x=\"450.816\" y=\"198.484\">2</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\" transform=\"rotate(0, 933.349, 1195.92)\" x=\"933.349\" y=\"1195.92\">time [s]</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\" transform=\"rotate(-90, 68.8189, 552.653)\" x=\"68.8189\" y=\"552.653\">d [m]</text>\n</g>\n<polyline clip-path=\"url(#clip2702)\" style=\"stroke:#009af9; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  525.058,1029.45 528.324,1029.32 531.591,1028.87 534.857,1028 538.123,1026.69 541.39,1024.85 544.656,1022.49 547.922,1019.5 551.189,1015.91 554.455,1011.63 \n  557.721,1006.67 560.988,1001.01 564.254,994.627 567.52,987.518 570.787,979.664 574.053,971.076 577.319,961.752 580.586,951.676 583.852,940.839 587.118,929.307 \n  590.385,917.127 593.651,904.271 596.917,890.75 600.184,876.648 603.45,862.063 606.716,846.975 609.983,831.419 613.249,815.465 616.515,799.221 619.782,782.694 \n  623.048,765.935 626.314,748.998 629.581,731.947 632.847,714.832 636.113,697.709 639.38,680.625 642.646,663.589 645.912,646.664 649.179,629.891 652.445,613.31 \n  655.711,596.937 658.977,580.81 662.244,564.96 665.51,549.412 668.776,534.209 672.043,519.37 675.309,504.918 678.575,490.878 681.842,477.281 685.108,464.146 \n  688.374,451.493 691.641,439.344 694.907,427.699 698.173,416.572 701.44,405.975 704.706,395.916 707.972,386.383 711.239,377.369 714.505,368.873 717.771,360.884 \n  721.038,353.392 724.304,346.385 727.57,339.843 730.837,333.748 734.103,328.086 737.369,322.849 740.636,318.014 743.902,313.564 747.168,309.483 750.435,305.752 \n  753.701,302.357 756.967,299.284 760.234,296.513 763.5,294.008 766.766,291.757 770.033,289.738 773.299,287.928 776.565,286.308 779.832,284.853 783.098,283.539 \n  786.364,282.341 789.631,281.234 792.897,280.194 796.163,279.192 799.43,278.206 802.696,277.292 805.962,276.382 809.228,275.458 812.495,274.501 815.761,273.496 \n  819.027,272.425 822.294,271.272 825.56,270.074 828.826,268.796 832.093,267.425 835.359,265.953 838.625,264.373 841.892,262.678 845.158,260.864 848.424,258.942 \n  851.691,256.905 854.957,254.749 858.223,252.476 861.49,250.087 864.756,247.586 868.022,244.975 871.289,242.259 874.555,239.442 877.821,236.532 881.088,233.537 \n  884.354,230.467 887.62,227.331 890.887,224.14 894.153,220.884 897.419,217.568 900.686,214.214 903.952,210.832 907.218,207.434 910.485,204.031 913.751,200.638 \n  917.017,197.245 920.284,193.846 923.55,190.47 926.816,187.126 930.083,183.826 933.349,180.578 936.615,177.394 939.882,174.274 943.148,171.207 946.414,168.215 \n  949.681,165.302 952.947,162.473 956.213,159.733 959.479,157.084 962.746,154.529 966.012,152.07 969.278,149.707 972.545,147.442 975.811,145.271 979.077,143.193 \n  982.344,141.205 985.61,139.306 988.876,137.518 992.143,135.821 995.409,134.214 998.675,132.693 1001.94,131.254 1005.21,129.892 1008.47,128.602 1011.74,127.396 \n  1015.01,126.261 1018.27,125.192 1021.54,124.185 1024.81,123.236 1028.07,122.34 1031.34,121.493 1034.6,120.696 1037.87,119.944 1041.14,119.232 1044.4,118.556 \n  1047.67,117.914 1050.94,117.303 1054.2,116.719 1057.47,116.158 1060.74,115.618 1064,115.096 1067.27,114.592 1070.53,114.102 1073.8,113.627 1077.07,113.164 \n  1080.33,112.706 1083.6,112.25 1086.87,111.797 1090.13,111.347 1093.4,110.897 1096.67,110.447 1099.93,109.996 1103.2,109.541 1106.46,109.082 1109.73,108.618 \n  1113,108.148 1116.26,107.672 1119.53,107.19 1122.8,106.702 1126.06,106.204 1129.33,105.694 1132.59,105.175 1135.86,104.646 1139.13,104.106 1142.39,103.556 \n  1145.66,102.994 1148.93,102.423 1152.19,101.844 1155.46,101.256 1158.73,100.66 1161.99,100.055 1165.26,99.4438 1168.52,98.8264 1171.79,98.2029 1175.06,97.5713 \n  1178.32,96.9346 1181.59,96.2935 1184.86,95.649 1188.12,95.0021 1191.39,94.3538 1194.65,93.7053 1197.92,93.0577 1201.19,92.4122 1204.45,91.7703 1207.72,91.1334 \n  1210.99,90.5028 1214.25,89.8802 1217.52,89.267 1220.79,88.6576 1224.05,88.0572 1227.32,87.4669 1230.58,86.8876 1233.85,86.3202 1237.12,85.7658 1240.38,85.2254 \n  1243.65,84.6998 1246.92,84.1901 1250.18,83.6973 1253.45,83.2224 1256.72,82.7662 1259.98,82.3298 1263.25,81.9142 1266.51,81.4909 1269.78,81.0765 1273.05,80.6779 \n  1276.31,80.2955 1279.58,79.9298 1282.85,79.5812 1286.11,79.2503 1289.38,78.9376 1292.64,78.6434 1295.91,78.3683 1299.18,78.1128 1302.44,77.8773 1305.71,77.6624 \n  1308.98,77.4685 1312.24,77.2687 1315.51,77.0641 1318.78,76.8716 1322.04,76.6913 1325.31,76.5227 1328.57,76.3659 1331.84,76.2206 1335.11,76.0866 1338.37,75.9639 \n  1341.64,75.8521 \n  \"/>\n<path clip-path=\"url(#clip2700)\" d=\"\nM1887.18 1058.06 L2752.76 1058.06 L2752.76 47.2441 L1887.18 47.2441  Z\n  \" fill=\"#ffffff\" fill-rule=\"evenodd\" fill-opacity=\"1\"/>\n<defs>\n  <clipPath id=\"clip2703\">\n    <rect x=\"1887\" y=\"47\" width=\"867\" height=\"1012\"/>\n  </clipPath>\n</defs>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1911.68,1058.06 1911.68,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2074.99,1058.06 2074.99,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2238.31,1058.06 2238.31,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2401.63,1058.06 2401.63,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2564.94,1058.06 2564.94,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  2728.26,1058.06 2728.26,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1887.18,839.753 2752.76,839.753 \n  \"/>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1887.18,617.715 2752.76,617.715 \n  \"/>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1887.18,395.677 2752.76,395.677 \n  \"/>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\" points=\"\n  1887.18,173.639 2752.76,173.639 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1887.18,1058.06 2752.76,1058.06 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1887.18,1058.06 1887.18,47.2441 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1911.68,1058.06 1911.68,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2074.99,1058.06 2074.99,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2238.31,1058.06 2238.31,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2401.63,1058.06 2401.63,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2564.94,1058.06 2564.94,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  2728.26,1058.06 2728.26,1045.93 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1887.18,839.753 1897.57,839.753 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1887.18,617.715 1897.57,617.715 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1887.18,395.677 1897.57,395.677 \n  \"/>\n<polyline clip-path=\"url(#clip2700)\" style=\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1887.18,173.639 1897.57,173.639 \n  \"/>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 1911.68, 1114.06)\" x=\"1911.68\" y=\"1114.06\">0.0</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 2074.99, 1114.06)\" x=\"2074.99\" y=\"1114.06\">0.1</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 2238.31, 1114.06)\" x=\"2238.31\" y=\"1114.06\">0.2</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 2401.63, 1114.06)\" x=\"2401.63\" y=\"1114.06\">0.3</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 2564.94, 1114.06)\" x=\"2564.94\" y=\"1114.06\">0.4</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\" transform=\"rotate(0, 2728.26, 1114.06)\" x=\"2728.26\" y=\"1114.06\">0.5</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 1559.01, 863.481)\" x=\"1559.01\" y=\"863.481\">6.59960×10</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 1814.6, 836.071)\" x=\"1814.6\" y=\"836.071\">-</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 1837.44, 836.071)\" x=\"1837.44\" y=\"836.071\">1</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 1559.01, 641.443)\" x=\"1559.01\" y=\"641.443\">6.59965×10</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 1814.6, 614.033)\" x=\"1814.6\" y=\"614.033\">-</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 1837.44, 614.033)\" x=\"1837.44\" y=\"614.033\">1</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 1559.01, 419.405)\" x=\"1559.01\" y=\"419.405\">6.59970×10</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 1814.6, 391.995)\" x=\"1814.6\" y=\"391.995\">-</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 1837.44, 391.995)\" x=\"1837.44\" y=\"391.995\">1</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\" transform=\"rotate(0, 1559.01, 197.367)\" x=\"1559.01\" y=\"197.367\">6.59975×10</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 1814.6, 169.957)\" x=\"1814.6\" y=\"169.957\">-</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\" transform=\"rotate(0, 1837.44, 169.957)\" x=\"1837.44\" y=\"169.957\">1</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\" transform=\"rotate(0, 2319.97, 1195.92)\" x=\"2319.97\" y=\"1195.92\">time [s]</text>\n</g>\n<g clip-path=\"url(#clip2700)\">\n<text style=\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\" transform=\"rotate(-90, 1482.2, 552.653)\" x=\"1482.2\" y=\"552.653\">v [V]</text>\n</g>\n<polyline clip-path=\"url(#clip2703)\" style=\"stroke:#009af9; stroke-width:4; stroke-opacity:1; fill:none\" points=\"\n  1911.68,1012.27 1914.94,1018.47 1918.21,1023.33 1921.48,1026.79 1924.74,1028.84 1928.01,1029.45 1931.27,1028.64 1934.54,1026.37 1937.81,1022.67 1941.07,1017.55 \n  1944.34,1011.02 1947.61,1003.12 1950.87,993.906 1954.14,983.388 1957.41,971.601 1960.67,958.623 1963.94,944.509 1967.2,929.286 1970.47,912.999 1973.74,895.778 \n  1977,877.731 1980.27,858.879 1983.54,839.289 1986.8,819.089 1990.07,798.424 1993.34,777.333 1996.6,755.901 1999.87,734.229 2003.13,712.429 2006.4,690.58 \n  2009.67,668.773 2012.93,647.083 2016.2,625.54 2019.47,604.243 2022.73,583.258 2026,562.646 2029.26,542.441 2032.53,522.705 2035.8,503.483 2039.06,484.817 \n  2042.33,466.747 2045.6,449.303 2048.86,432.516 2052.13,416.41 2055.4,401.028 2058.66,386.382 2061.93,372.492 2065.19,359.371 2068.46,347.034 2071.73,335.487 \n  2074.99,324.737 2078.26,314.784 2081.53,305.613 2084.79,297.213 2088.06,289.573 2091.32,282.674 2094.59,276.492 2097.86,270.997 2101.12,266.159 2104.39,261.94 \n  2107.66,258.318 2110.92,255.267 2114.19,252.747 2117.46,250.721 2120.72,249.158 2123.99,248.025 2127.25,247.289 2130.52,246.919 2133.79,246.88 2137.05,247.131 \n  2140.32,247.644 2143.59,248.388 2146.85,249.328 2150.12,250.418 2153.39,251.627 2156.65,252.919 2159.92,254.263 2163.18,255.651 2166.45,257.044 2169.72,258.413 \n  2172.98,259.731 2176.25,260.975 2179.52,262.119 2182.78,263.139 2186.05,264.014 2189.31,264.74 2192.58,265.288 2195.85,265.639 2199.11,265.779 2202.38,265.691 \n  2205.65,265.363 2208.91,264.78 2212.18,264.007 2215.45,263.004 2218.71,261.766 2221.98,260.293 2225.24,258.59 2228.51,256.661 2231.78,254.514 2235.04,252.139 \n  2238.31,249.553 2241.58,246.768 2244.84,243.797 2248.11,240.653 2251.37,237.352 2254.64,233.913 2257.91,230.319 2261.17,226.591 2264.44,222.757 2267.71,218.834 \n  2270.97,214.844 2274.24,210.807 2277.51,206.745 2280.77,202.634 2284.04,198.481 2287.3,194.327 2290.57,190.191 2293.84,186.09 2297.1,182.042 2300.37,178.068 \n  2303.64,174.151 2306.9,170.281 2310.17,166.499 2313.44,162.816 2316.7,159.245 2319.97,155.796 2323.23,152.482 2326.5,149.301 2329.77,146.238 2333.03,143.316 \n  2336.3,140.536 2339.57,137.902 2342.83,135.413 2346.1,133.069 2349.36,130.871 2352.63,128.827 2355.9,126.927 2359.16,125.166 2362.43,123.539 2365.7,122.04 \n  2368.96,120.659 2372.23,119.393 2375.5,118.265 2378.76,117.248 2382.03,116.334 2385.29,115.517 2388.56,114.786 2391.83,114.135 2395.09,113.553 2398.36,113.058 \n  2401.63,112.627 2404.89,112.254 2408.16,111.934 2411.42,111.66 2414.69,111.427 2417.96,111.229 2421.22,111.056 2424.49,110.905 2427.76,110.772 2431.02,110.653 \n  2434.29,110.543 2437.56,110.44 2440.82,110.342 2444.09,110.237 2447.35,110.127 2450.62,110.01 2453.89,109.885 2457.15,109.751 2460.42,109.608 2463.69,109.456 \n  2466.95,109.281 2470.22,109.08 2473.49,108.86 2476.75,108.617 2480.02,108.353 2483.28,108.065 2486.55,107.754 2489.82,107.419 2493.08,107.058 2496.35,106.674 \n  2499.62,106.266 2502.88,105.835 2506.15,105.382 2509.41,104.907 2512.68,104.408 2515.95,103.883 2519.21,103.336 2522.48,102.767 2525.75,102.177 2529.01,101.568 \n  2532.28,100.941 2535.55,100.297 2538.81,99.6386 2542.08,98.9664 2545.34,98.2825 2548.61,97.5887 2551.88,96.8873 2555.14,96.1804 2558.41,95.4682 2561.68,94.7458 \n  2564.94,94.0198 2568.21,93.2919 2571.47,92.5638 2574.74,91.8371 2578.01,91.1137 2581.27,90.3952 2584.54,89.6836 2587.81,88.9809 2591.07,88.2888 2594.34,87.6094 \n  2597.61,86.9448 2600.87,86.297 2604.14,85.6676 2607.4,85.0371 2610.67,84.4235 2613.94,83.828 2617.2,83.2521 2620.47,82.6972 2623.74,82.1646 2627,81.6559 \n  2630.27,81.1723 2633.54,80.7153 2636.8,80.2863 2640.07,79.8867 2643.33,79.5179 2646.6,79.1813 2649.87,78.8783 2653.13,78.5497 2656.4,78.2294 2659.67,77.9306 \n  2662.93,77.6537 2666.2,77.399 2669.46,77.167 2672.73,76.9579 2676,76.7722 2679.26,76.6103 2682.53,76.4725 2685.8,76.3592 2689.06,76.2709 2692.33,76.2079 \n  2695.6,76.1705 2698.86,76.1173 2702.13,76.0495 2705.39,75.9928 2708.66,75.9466 2711.93,75.9104 2715.19,75.8834 2718.46,75.8651 2721.73,75.8549 2724.99,75.8521 \n  2728.26,75.8563 \n  \"/>\n</svg>\n"
+               },
+               "type": "node"
+              }
+             ],
+             "instanceArgs": {
+              "namespace": "html",
+              "tag": "div"
+             },
+             "nodeType": "DOM",
+             "props": {
+              "className": "interact-flex-row interact-widget"
+             },
+             "type": "node"
+            }
+           }
+          },
+          "systemjs_options": null
+         },
+         "nodeType": "Scope",
+         "props": {},
+         "type": "node"
+        }
+       ],
+       "instanceArgs": {
+        "namespace": "html",
+        "tag": "div"
+       },
+       "nodeType": "DOM",
+       "props": {},
+       "type": "node"
+      },
+      "text/html": [
+       "<div\n",
+       "    class=\"webio-mountpoint\"\n",
+       "    data-webio-mountpoint=\"17495209582925667918\"\n",
+       ">\n",
+       "    <script>\n",
+       "    if (window.require && require.defined && require.defined(\"nbextensions/webio-jupyter-notebook\")) {\n",
+       "        console.log(\"Jupyter WebIO extension detected, not mounting.\");\n",
+       "    } else if (window.WebIO) {\n",
+       "        WebIO.mount(\n",
+       "            document.querySelector('[data-webio-mountpoint=\"17495209582925667918\"]'),\n",
+       "            {\"props\":{},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"field interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{},\"nodeType\":\"Scope\",\"type\":\"node\",\"instanceArgs\":{\"imports\":{\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"},{\"name\":null,\"type\":\"js\",\"url\":\"\\/assetserver\\/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css\"}],\"type\":\"async_block\"},\"id\":\"5522547382221971813\",\"handlers\":{\"changes\":[\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\"],\"index\":[\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\"]},\"systemjs_options\":null,\"mount_callbacks\":[\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"7.0\\\",\\\"7.5\\\",\\\"8.0\\\",\\\"8.5\\\",\\\"9.0\\\",\\\"9.5\\\",\\\"10.0\\\",\\\"10.5\\\",\\\"11.0\\\",\\\"11.5\\\",\\\"12.0\\\",\\\"12.5\\\",\\\"13.0\\\",\\\"13.5\\\",\\\"14.0\\\",\\\"14.5\\\",\\\"15.0\\\",\\\"15.5\\\",\\\"16.0\\\",\\\"16.5\\\",\\\"17.0\\\",\\\"17.5\\\",\\\"18.0\\\",\\\"18.5\\\",\\\"19.0\\\",\\\"19.5\\\",\\\"20.0\\\",\\\"20.5\\\",\\\"21.0\\\",\\\"21.5\\\",\\\"22.0\\\",\\\"22.5\\\",\\\"23.0\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"5522547382221971813\\\",\\\"id\\\":\\\"ob_15\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"5522547382221971813\\\",\\\"id\\\":\\\"ob_14\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"5522547382221971813\\\",\\\"id\\\":\\\"ob_15\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"5522547382221971813\\\",\\\"id\\\":\\\"ob_14\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\"],\"observables\":{\"changes\":{\"sync\":false,\"id\":\"ob_15\",\"value\":0},\"index\":{\"sync\":true,\"id\":\"ob_14\",\"value\":17}}},\"children\":[{\"props\":{\"className\":\"interact-flex-row interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact-flex-row-left\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact \",\"style\":{\"padding\":\"5px 10px 0px 10px\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"label\"},\"children\":[\"Kp\"]}]},{\"props\":{\"className\":\"interact-flex-row-center\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"max\":33,\"min\":1,\"attributes\":{\"type\":\"range\",\"data-bind\":\"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\":\"horizontal\"},\"step\":1,\"className\":\"slider slider is-fullwidth\",\"style\":{}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"input\"},\"children\":[]}]},{\"props\":{\"className\":\"interact-flex-row-right\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"attributes\":{\"data-bind\":\"text: formatted_val\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"p\"},\"children\":[]}]}]}]}]},{\"props\":{\"className\":\"field interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{},\"nodeType\":\"Scope\",\"type\":\"node\",\"instanceArgs\":{\"imports\":{\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"},{\"name\":null,\"type\":\"js\",\"url\":\"\\/assetserver\\/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css\"}],\"type\":\"async_block\"},\"id\":\"5835400797425742633\",\"handlers\":{\"changes\":[\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\"],\"index\":[\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\"]},\"systemjs_options\":null,\"mount_callbacks\":[\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"0.01\\\",\\\"0.02\\\",\\\"0.03\\\",\\\"0.04\\\",\\\"0.05\\\",\\\"0.06\\\",\\\"0.07\\\",\\\"0.08\\\",\\\"0.09\\\",\\\"0.1\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"5835400797425742633\\\",\\\"id\\\":\\\"ob_18\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"5835400797425742633\\\",\\\"id\\\":\\\"ob_17\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"5835400797425742633\\\",\\\"id\\\":\\\"ob_18\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"5835400797425742633\\\",\\\"id\\\":\\\"ob_17\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\"],\"observables\":{\"changes\":{\"sync\":false,\"id\":\"ob_18\",\"value\":0},\"index\":{\"sync\":true,\"id\":\"ob_17\",\"value\":5}}},\"children\":[{\"props\":{\"className\":\"interact-flex-row interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact-flex-row-left\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact \",\"style\":{\"padding\":\"5px 10px 0px 10px\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"label\"},\"children\":[\"Td\"]}]},{\"props\":{\"className\":\"interact-flex-row-center\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"max\":10,\"min\":1,\"attributes\":{\"type\":\"range\",\"data-bind\":\"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\":\"horizontal\"},\"step\":1,\"className\":\"slider slider is-fullwidth\",\"style\":{}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"input\"},\"children\":[]}]},{\"props\":{\"className\":\"interact-flex-row-right\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"attributes\":{\"data-bind\":\"text: formatted_val\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"p\"},\"children\":[]}]}]}]}]},{\"props\":{\"className\":\"field interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{},\"nodeType\":\"Scope\",\"type\":\"node\",\"instanceArgs\":{\"imports\":{\"data\":[{\"name\":\"knockout\",\"type\":\"js\",\"url\":\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\"},{\"name\":\"knockout_punches\",\"type\":\"js\",\"url\":\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\"},{\"name\":null,\"type\":\"js\",\"url\":\"\\/assetserver\\/87fbb56094a247daf1214cc247e1ea75dde753d2-all.js\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/c534eb49f13f34be6f01b330c053e85ea088a5dd-style.css\"},{\"name\":null,\"type\":\"css\",\"url\":\"\\/assetserver\\/6dcba856e529d0932918770e60454e5647e7c847-bulma_confined.min.css\"}],\"type\":\"async_block\"},\"id\":\"4044788257546097905\",\"handlers\":{\"changes\":[\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\"],\"index\":[\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\"]},\"systemjs_options\":null,\"mount_callbacks\":[\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"0.015\\\",\\\"0.0152\\\",\\\"0.0154\\\",\\\"0.0156\\\",\\\"0.0158\\\",\\\"0.016\\\",\\\"0.0162\\\",\\\"0.0164\\\",\\\"0.0166\\\",\\\"0.0168\\\",\\\"0.017\\\",\\\"0.0172\\\",\\\"0.0174\\\",\\\"0.0176\\\",\\\"0.0178\\\",\\\"0.018\\\",\\\"0.0182\\\",\\\"0.0184\\\",\\\"0.0186\\\",\\\"0.0188\\\",\\\"0.019\\\",\\\"0.0192\\\",\\\"0.0194\\\",\\\"0.0196\\\",\\\"0.0198\\\",\\\"0.02\\\",\\\"0.0202\\\",\\\"0.0204\\\",\\\"0.0206\\\",\\\"0.0208\\\",\\\"0.021\\\",\\\"0.0212\\\",\\\"0.0214\\\",\\\"0.0216\\\",\\\"0.0218\\\",\\\"0.022\\\",\\\"0.0222\\\",\\\"0.0224\\\",\\\"0.0226\\\",\\\"0.0228\\\",\\\"0.023\\\",\\\"0.0232\\\",\\\"0.0234\\\",\\\"0.0236\\\",\\\"0.0238\\\",\\\"0.024\\\",\\\"0.0242\\\",\\\"0.0244\\\",\\\"0.0246\\\",\\\"0.0248\\\",\\\"0.025\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"4044788257546097905\\\",\\\"id\\\":\\\"ob_21\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"4044788257546097905\\\",\\\"id\\\":\\\"ob_20\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"4044788257546097905\\\",\\\"id\\\":\\\"ob_21\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"4044788257546097905\\\",\\\"id\\\":\\\"ob_20\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"\\/assetserver\\/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\"],\"observables\":{\"changes\":{\"sync\":false,\"id\":\"ob_21\",\"value\":0},\"index\":{\"sync\":true,\"id\":\"ob_20\",\"value\":26}}},\"children\":[{\"props\":{\"className\":\"interact-flex-row interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact-flex-row-left\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"className\":\"interact \",\"style\":{\"padding\":\"5px 10px 0px 10px\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"label\"},\"children\":[\"d0\"]}]},{\"props\":{\"className\":\"interact-flex-row-center\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"max\":51,\"min\":1,\"attributes\":{\"type\":\"range\",\"data-bind\":\"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\":\"horizontal\"},\"step\":1,\"className\":\"slider slider is-fullwidth\",\"style\":{}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"input\"},\"children\":[]}]},{\"props\":{\"className\":\"interact-flex-row-right\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"attributes\":{\"data-bind\":\"text: formatted_val\"}},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"p\"},\"children\":[]}]}]}]}]},{\"props\":{},\"nodeType\":\"Scope\",\"type\":\"node\",\"instanceArgs\":{\"imports\":{\"data\":[],\"type\":\"async_block\"},\"id\":\"17695314114139818369\",\"handlers\":{},\"systemjs_options\":null,\"mount_callbacks\":[],\"observables\":{\"obs-node\":{\"sync\":false,\"id\":\"ob_25\",\"value\":{\"props\":{\"className\":\"interact-flex-row interact-widget\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[{\"props\":{\"setInnerHtml\":\"<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\"?>\\n<svg xmlns=\\\"http:\\/\\/www.w3.org\\/2000\\/svg\\\" xmlns:xlink=\\\"http:\\/\\/www.w3.org\\/1999\\/xlink\\\" width=\\\"700\\\" height=\\\"300\\\" viewBox=\\\"0 0 2800 1200\\\">\\n<defs>\\n  <clipPath id=\\\"clip2300\\\">\\n    <rect x=\\\"0\\\" y=\\\"0\\\" width=\\\"2800\\\" height=\\\"1200\\\"\\/>\\n  <\\/clipPath>\\n<\\/defs>\\n<path clip-path=\\\"url(#clip2300)\\\" d=\\\"\\nM0 1200 L2800 1200 L2800 0 L0 0  Z\\n  \\\" fill=\\\"#ffffff\\\" fill-rule=\\\"evenodd\\\" fill-opacity=\\\"1\\\"\\/>\\n<defs>\\n  <clipPath id=\\\"clip2301\\\">\\n    <rect x=\\\"560\\\" y=\\\"0\\\" width=\\\"1961\\\" height=\\\"1200\\\"\\/>\\n  <\\/clipPath>\\n<\\/defs>\\n<path clip-path=\\\"url(#clip2300)\\\" d=\\\"\\nM513.028 1025.62 L1366.14 1025.62 L1366.14 47.2441 L513.028 47.2441  Z\\n  \\\" fill=\\\"#ffffff\\\" fill-rule=\\\"evenodd\\\" fill-opacity=\\\"1\\\"\\/>\\n<defs>\\n  <clipPath id=\\\"clip2302\\\">\\n    <rect x=\\\"513\\\" y=\\\"47\\\" width=\\\"854\\\" height=\\\"979\\\"\\/>\\n  <\\/clipPath>\\n<\\/defs>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  537.172,1025.62 537.172,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  698.136,1025.62 698.136,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  859.1,1025.62 859.1,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1020.06,1025.62 1020.06,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1181.03,1025.62 1181.03,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1341.99,1025.62 1341.99,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  513.028,936.334 1366.14,936.334 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  513.028,751.549 1366.14,751.549 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  513.028,566.764 1366.14,566.764 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  513.028,381.979 1366.14,381.979 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  513.028,197.194 1366.14,197.194 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  513.028,1025.62 1366.14,1025.62 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  513.028,1025.62 513.028,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  537.172,1025.62 537.172,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  698.136,1025.62 698.136,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  859.1,1025.62 859.1,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1020.06,1025.62 1020.06,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1181.03,1025.62 1181.03,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1341.99,1025.62 1341.99,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  513.028,936.334 523.265,936.334 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  513.028,751.549 523.265,751.549 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  513.028,566.764 523.265,566.764 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  513.028,381.979 523.265,381.979 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  513.028,197.194 523.265,197.194 \\n  \\\"\\/>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 537.172, 1081.62)\\\" x=\\\"537.172\\\" y=\\\"1081.62\\\">0.0<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 698.136, 1081.62)\\\" x=\\\"698.136\\\" y=\\\"1081.62\\\">0.1<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 859.1, 1081.62)\\\" x=\\\"859.1\\\" y=\\\"1081.62\\\">0.2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 1020.06, 1081.62)\\\" x=\\\"1020.06\\\" y=\\\"1081.62\\\">0.3<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 1181.03, 1081.62)\\\" x=\\\"1181.03\\\" y=\\\"1081.62\\\">0.4<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 1341.99, 1081.62)\\\" x=\\\"1341.99\\\" y=\\\"1081.62\\\">0.5<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 158.092, 960.061)\\\" x=\\\"158.092\\\" y=\\\"960.061\\\">2.000001×10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 440.444, 932.651)\\\" x=\\\"440.444\\\" y=\\\"932.651\\\">-<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 463.283, 932.651)\\\" x=\\\"463.283\\\" y=\\\"932.651\\\">2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 158.092, 775.277)\\\" x=\\\"158.092\\\" y=\\\"775.277\\\">2.000004×10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 440.444, 747.866)\\\" x=\\\"440.444\\\" y=\\\"747.866\\\">-<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 463.283, 747.866)\\\" x=\\\"463.283\\\" y=\\\"747.866\\\">2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 158.092, 590.492)\\\" x=\\\"158.092\\\" y=\\\"590.492\\\">2.000007×10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 440.444, 563.081)\\\" x=\\\"440.444\\\" y=\\\"563.081\\\">-<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 463.283, 563.081)\\\" x=\\\"463.283\\\" y=\\\"563.081\\\">2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 158.092, 405.707)\\\" x=\\\"158.092\\\" y=\\\"405.707\\\">2.000010×10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 440.444, 378.296)\\\" x=\\\"440.444\\\" y=\\\"378.296\\\">-<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 463.283, 378.296)\\\" x=\\\"463.283\\\" y=\\\"378.296\\\">2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 158.092, 220.922)\\\" x=\\\"158.092\\\" y=\\\"220.922\\\">2.000013×10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 440.444, 193.512)\\\" x=\\\"440.444\\\" y=\\\"193.512\\\">-<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 463.283, 193.512)\\\" x=\\\"463.283\\\" y=\\\"193.512\\\">2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\\\" transform=\\\"rotate(0, 939.582, 1163.48)\\\" x=\\\"939.582\\\" y=\\\"1163.48\\\">time [s]<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\\\" transform=\\\"rotate(-90, 81.2861, 536.431)\\\" x=\\\"81.2861\\\" y=\\\"536.431\\\">d [m]<\\/text>\\n<\\/g>\\n<polyline clip-path=\\\"url(#clip2302)\\\" style=\\\"stroke:#009af9; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  537.172,997.929 540.392,997.804 543.611,997.368 546.83,996.52 550.05,995.254 553.269,993.469 556.488,991.185 559.707,988.298 562.927,984.817 566.146,980.675 \\n  569.365,975.872 572.585,970.394 575.804,964.219 579.023,957.339 582.242,949.737 585.462,941.425 588.681,932.4 591.9,922.647 595.119,912.158 598.339,900.997 \\n  601.558,889.207 604.777,876.764 607.997,863.677 611.216,850.027 614.435,835.911 617.654,821.307 620.874,806.25 624.093,790.808 627.312,775.085 630.532,759.089 \\n  633.751,742.868 636.97,726.474 640.189,709.971 643.409,693.405 646.628,676.831 649.847,660.296 653.067,643.807 656.286,627.425 659.505,611.191 662.724,595.142 \\n  665.944,579.294 669.163,563.685 672.382,548.343 675.601,533.295 678.821,518.579 682.04,504.216 685.259,490.229 688.479,476.64 691.698,463.478 694.917,450.765 \\n  698.136,438.518 701.356,426.759 704.575,415.488 707.794,404.718 711.014,394.461 714.233,384.725 717.452,375.498 720.671,366.773 723.891,358.55 727.11,350.817 \\n  730.329,343.566 733.549,336.783 736.768,330.452 739.987,324.552 743.206,319.072 746.426,314.003 749.645,309.323 752.864,305.016 756.083,301.066 759.303,297.455 \\n  762.522,294.169 765.741,291.194 768.961,288.512 772.18,286.087 775.399,283.909 778.618,281.955 781.838,280.203 785.057,278.635 788.276,277.227 791.496,275.954 \\n  794.715,274.795 797.934,273.724 801.153,272.717 804.373,271.748 807.592,270.793 810.811,269.908 814.031,269.028 817.25,268.133 820.469,267.207 823.688,266.234 \\n  826.908,265.197 830.127,264.081 833.346,262.922 836.565,261.685 839.785,260.358 843.004,258.933 846.223,257.404 849.443,255.764 852.662,254.008 855.881,252.147 \\n  859.1,250.175 862.32,248.089 865.539,245.889 868.758,243.577 871.978,241.156 875.197,238.629 878.416,235.999 881.635,233.273 884.855,230.456 888.074,227.558 \\n  891.293,224.586 894.513,221.551 897.732,218.462 900.951,215.311 904.17,212.101 907.39,208.855 910.609,205.581 913.828,202.292 917.047,198.999 920.267,195.715 \\n  923.486,192.43 926.705,189.141 929.925,185.873 933.144,182.637 936.363,179.442 939.582,176.299 942.802,173.217 946.021,170.197 949.24,167.229 952.46,164.332 \\n  955.679,161.513 958.898,158.775 962.117,156.122 965.337,153.558 968.556,151.085 971.775,148.705 974.995,146.419 978.214,144.226 981.433,142.125 984.652,140.114 \\n  987.872,138.189 991.091,136.351 994.31,134.62 997.53,132.978 1000.75,131.423 1003.97,129.951 1007.19,128.558 1010.41,127.239 1013.63,125.99 1016.85,124.823 \\n  1020.06,123.725 1023.28,122.69 1026.5,121.716 1029.72,120.797 1032.94,119.93 1036.16,119.11 1039.38,118.339 1042.6,117.611 1045.82,116.921 1049.04,116.267 \\n  1052.26,115.646 1055.48,115.054 1058.7,114.489 1061.92,113.946 1065.13,113.423 1068.35,112.918 1071.57,112.43 1074.79,111.956 1078.01,111.496 1081.23,111.049 \\n  1084.45,110.605 1087.67,110.163 1090.89,109.725 1094.11,109.289 1097.33,108.854 1100.55,108.419 1103.77,107.982 1106.99,107.542 1110.2,107.097 1113.42,106.648 \\n  1116.64,106.193 1119.86,105.733 1123.08,105.266 1126.3,104.793 1129.52,104.311 1132.74,103.818 1135.96,103.316 1139.18,102.803 1142.4,102.281 1145.62,101.748 \\n  1148.84,101.205 1152.05,100.652 1155.27,100.092 1158.49,99.5225 1161.71,98.9451 1164.93,98.3601 1168.15,97.7684 1171.37,97.1708 1174.59,96.5673 1177.81,95.956 \\n  1181.03,95.3397 1184.25,94.7192 1187.47,94.0954 1190.69,93.4693 1193.91,92.8418 1197.12,92.2141 1200.34,91.5872 1203.56,90.9625 1206.78,90.3412 1210,89.7247 \\n  1213.22,89.1144 1216.44,88.5118 1219.66,87.9182 1222.88,87.3284 1226.1,86.7473 1229.32,86.1759 1232.54,85.6152 1235.76,85.066 1238.98,84.5294 1242.19,84.0063 \\n  1245.41,83.4976 1248.63,83.0043 1251.85,82.5273 1255.07,82.0676 1258.29,81.6261 1261.51,81.2037 1264.73,80.8015 1267.95,80.3917 1271.17,79.9906 1274.39,79.6048 \\n  1277.61,79.2347 1280.83,78.8807 1284.05,78.5433 1287.26,78.2231 1290.48,77.9203 1293.7,77.6356 1296.92,77.3693 1300.14,77.122 1303.36,76.8941 1306.58,76.6861 \\n  1309.8,76.4984 1313.02,76.305 1316.24,76.107 1319.46,75.9207 1322.68,75.7461 1325.9,75.583 1329.12,75.4312 1332.33,75.2906 1335.55,75.1609 1338.77,75.0421 \\n  1341.99,74.9339 \\n  \\\"\\/>\\n<path clip-path=\\\"url(#clip2300)\\\" d=\\\"\\nM1899.65 1025.62 L2752.76 1025.62 L2752.76 47.2441 L1899.65 47.2441  Z\\n  \\\" fill=\\\"#ffffff\\\" fill-rule=\\\"evenodd\\\" fill-opacity=\\\"1\\\"\\/>\\n<defs>\\n  <clipPath id=\\\"clip2303\\\">\\n    <rect x=\\\"1899\\\" y=\\\"47\\\" width=\\\"854\\\" height=\\\"979\\\"\\/>\\n  <\\/clipPath>\\n<\\/defs>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1923.79,1025.62 1923.79,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2084.76,1025.62 2084.76,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2245.72,1025.62 2245.72,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2406.68,1025.62 2406.68,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2567.65,1025.62 2567.65,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  2728.61,1025.62 2728.61,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1899.65,814.317 2752.76,814.317 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1899.65,599.405 2752.76,599.405 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1899.65,384.494 2752.76,384.494 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#000000; stroke-width:2; stroke-opacity:0.1; fill:none\\\" points=\\\"\\n  1899.65,169.583 2752.76,169.583 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1899.65,1025.62 2752.76,1025.62 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1899.65,1025.62 1899.65,47.2441 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1923.79,1025.62 1923.79,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2084.76,1025.62 2084.76,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2245.72,1025.62 2245.72,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2406.68,1025.62 2406.68,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2567.65,1025.62 2567.65,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  2728.61,1025.62 2728.61,1013.88 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1899.65,814.317 1909.88,814.317 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1899.65,599.405 1909.88,599.405 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1899.65,384.494 1909.88,384.494 \\n  \\\"\\/>\\n<polyline clip-path=\\\"url(#clip2300)\\\" style=\\\"stroke:#000000; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1899.65,169.583 1909.88,169.583 \\n  \\\"\\/>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 1923.79, 1081.62)\\\" x=\\\"1923.79\\\" y=\\\"1081.62\\\">0.0<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 2084.76, 1081.62)\\\" x=\\\"2084.76\\\" y=\\\"1081.62\\\">0.1<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 2245.72, 1081.62)\\\" x=\\\"2245.72\\\" y=\\\"1081.62\\\">0.2<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 2406.68, 1081.62)\\\" x=\\\"2406.68\\\" y=\\\"1081.62\\\">0.3<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 2567.65, 1081.62)\\\" x=\\\"2567.65\\\" y=\\\"1081.62\\\">0.4<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:middle;\\\" transform=\\\"rotate(0, 2728.61, 1081.62)\\\" x=\\\"2728.61\\\" y=\\\"1081.62\\\">0.5<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 1571.47, 838.045)\\\" x=\\\"1571.47\\\" y=\\\"838.045\\\">6.59960×10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 1827.06, 810.634)\\\" x=\\\"1827.06\\\" y=\\\"810.634\\\">-<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 1849.9, 810.634)\\\" x=\\\"1849.9\\\" y=\\\"810.634\\\">1<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 1571.47, 623.133)\\\" x=\\\"1571.47\\\" y=\\\"623.133\\\">6.59965×10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 1827.06, 595.723)\\\" x=\\\"1827.06\\\" y=\\\"595.723\\\">-<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 1849.9, 595.723)\\\" x=\\\"1849.9\\\" y=\\\"595.723\\\">1<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 1571.47, 408.222)\\\" x=\\\"1571.47\\\" y=\\\"408.222\\\">6.59970×10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 1827.06, 380.811)\\\" x=\\\"1827.06\\\" y=\\\"380.811\\\">-<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 1849.9, 380.811)\\\" x=\\\"1849.9\\\" y=\\\"380.811\\\">1<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:48px; text-anchor:start;\\\" transform=\\\"rotate(0, 1571.47, 193.31)\\\" x=\\\"1571.47\\\" y=\\\"193.31\\\">6.59975×10<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 1827.06, 165.9)\\\" x=\\\"1827.06\\\" y=\\\"165.9\\\">-<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:38px; text-anchor:start;\\\" transform=\\\"rotate(0, 1849.9, 165.9)\\\" x=\\\"1849.9\\\" y=\\\"165.9\\\">1<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\\\" transform=\\\"rotate(0, 2326.2, 1163.48)\\\" x=\\\"2326.2\\\" y=\\\"1163.48\\\">time [s]<\\/text>\\n<\\/g>\\n<g clip-path=\\\"url(#clip2300)\\\">\\n<text style=\\\"fill:#000000; fill-opacity:1; font-family:Arial,Helvetica Neue,Helvetica,sans-serif; font-size:66px; text-anchor:middle;\\\" transform=\\\"rotate(-90, 1494.67, 536.431)\\\" x=\\\"1494.67\\\" y=\\\"536.431\\\">v [V]<\\/text>\\n<\\/g>\\n<polyline clip-path=\\\"url(#clip2303)\\\" style=\\\"stroke:#009af9; stroke-width:4; stroke-opacity:1; fill:none\\\" points=\\\"\\n  1923.79,981.297 1927.01,987.302 1930.23,992.004 1933.45,995.349 1936.67,997.335 1939.89,997.929 1943.11,997.137 1946.33,994.948 1949.55,991.363 1952.76,986.41 \\n  1955.98,980.087 1959.2,972.445 1962.42,963.522 1965.64,953.341 1968.86,941.933 1972.08,929.372 1975.3,915.71 1978.52,900.976 1981.74,885.212 1984.96,868.544 \\n  1988.18,851.076 1991.4,832.829 1994.62,813.867 1997.83,794.316 2001.05,774.314 2004.27,753.9 2007.49,733.156 2010.71,712.179 2013.93,691.08 2017.15,669.931 \\n  2020.37,648.824 2023.59,627.831 2026.81,606.979 2030.03,586.365 2033.25,566.054 2036.47,546.104 2039.69,526.547 2042.9,507.444 2046.12,488.84 2049.34,470.773 \\n  2052.56,453.282 2055.78,436.399 2059,420.15 2062.22,404.562 2065.44,389.673 2068.66,375.497 2071.88,362.053 2075.1,349.353 2078.32,337.412 2081.54,326.236 \\n  2084.76,315.83 2087.97,306.197 2091.19,297.32 2094.41,289.19 2097.63,281.795 2100.85,275.118 2104.07,269.134 2107.29,263.815 2110.51,259.132 2113.73,255.049 \\n  2116.95,251.543 2120.17,248.591 2123.39,246.151 2126.61,244.19 2129.83,242.677 2133.04,241.58 2136.26,240.868 2139.48,240.51 2142.7,240.473 2145.92,240.715 \\n  2149.14,241.212 2152.36,241.932 2155.58,242.842 2158.8,243.897 2162.02,245.067 2165.24,246.318 2168.46,247.618 2171.68,248.962 2174.9,250.31 2178.11,251.635 \\n  2181.33,252.911 2184.55,254.115 2187.77,255.222 2190.99,256.21 2194.21,257.057 2197.43,257.76 2200.65,258.289 2203.87,258.63 2207.09,258.765 2210.31,258.68 \\n  2213.53,258.362 2216.75,257.798 2219.97,257.05 2223.18,256.079 2226.4,254.881 2229.62,253.455 2232.84,251.807 2236.06,249.94 2239.28,247.861 2242.5,245.563 \\n  2245.72,243.06 2248.94,240.364 2252.16,237.488 2255.38,234.445 2258.6,231.251 2261.82,227.921 2265.03,224.443 2268.25,220.835 2271.47,217.123 2274.69,213.327 \\n  2277.91,209.465 2281.13,205.557 2284.35,201.626 2287.57,197.647 2290.79,193.627 2294.01,189.606 2297.23,185.603 2300.45,181.633 2303.67,177.716 2306.89,173.869 \\n  2310.1,170.078 2313.32,166.332 2316.54,162.671 2319.76,159.106 2322.98,155.65 2326.2,152.312 2329.42,149.105 2332.64,146.025 2335.86,143.061 2339.08,140.232 \\n  2342.3,137.542 2345.52,134.992 2348.74,132.583 2351.96,130.314 2355.17,128.187 2358.39,126.209 2361.61,124.369 2364.83,122.665 2368.05,121.09 2371.27,119.639 \\n  2374.49,118.303 2377.71,117.078 2380.93,115.986 2384.15,115.001 2387.37,114.117 2390.59,113.325 2393.81,112.619 2397.03,111.988 2400.24,111.425 2403.46,110.945 \\n  2406.68,110.528 2409.9,110.168 2413.12,109.858 2416.34,109.593 2419.56,109.367 2422.78,109.175 2426,109.008 2429.22,108.862 2432.44,108.733 2435.66,108.617 \\n  2438.88,108.511 2442.1,108.412 2445.31,108.316 2448.53,108.215 2451.75,108.109 2454.97,107.995 2458.19,107.874 2461.41,107.744 2464.63,107.606 2467.85,107.459 \\n  2471.07,107.289 2474.29,107.096 2477.51,106.882 2480.73,106.648 2483.95,106.391 2487.17,106.113 2490.38,105.812 2493.6,105.487 2496.82,105.139 2500.04,104.767 \\n  2503.26,104.372 2506.48,103.954 2509.7,103.516 2512.92,103.056 2516.14,102.573 2519.36,102.065 2522.58,101.535 2525.8,100.985 2529.02,100.414 2532.24,99.8248 \\n  2535.45,99.2178 2538.67,98.5946 2541.89,97.957 2545.11,97.3063 2548.33,96.6443 2551.55,95.9729 2554.77,95.294 2557.99,94.6098 2561.21,93.9204 2564.43,93.2212 \\n  2567.65,92.5185 2570.87,91.814 2574.09,91.1092 2577.31,90.4059 2580.52,89.7056 2583.74,89.0102 2586.96,88.3215 2590.18,87.6413 2593.4,86.9714 2596.62,86.3139 \\n  2599.84,85.6706 2603.06,85.0436 2606.28,84.4343 2609.5,83.8241 2612.72,83.2302 2615.94,82.6538 2619.16,82.0964 2622.38,81.5593 2625.59,81.0438 2628.81,80.5514 \\n  2632.03,80.0833 2635.25,79.641 2638.47,79.2258 2641.69,78.839 2644.91,78.482 2648.13,78.1562 2651.35,77.8629 2654.57,77.5449 2657.79,77.2349 2661.01,76.9457 \\n  2664.23,76.6777 2667.44,76.4312 2670.66,76.2065 2673.88,76.0042 2677.1,75.8244 2680.32,75.6677 2683.54,75.5344 2686.76,75.4247 2689.98,75.3393 2693.2,75.2782 \\n  2696.42,75.2421 2699.64,75.1906 2702.86,75.125 2706.08,75.0701 2709.3,75.0254 2712.51,74.9903 2715.73,74.9642 2718.95,74.9465 2722.17,74.9366 2725.39,74.9339 \\n  2728.61,74.9379 \\n  \\\"\\/>\\n<\\/svg>\\n\"},\"nodeType\":\"DOM\",\"type\":\"node\",\"instanceArgs\":{\"namespace\":\"html\",\"tag\":\"div\"},\"children\":[]}]}}}},\"children\":[{\"props\":{},\"nodeType\":\"ObservableNode\",\"type\":\"node\",\"instanceArgs\":{\"id\":\"ob_25\",\"name\":\"obs-node\"},\"children\":[]}]}]},\n",
+       "            window,\n",
+       "        );\n",
+       "    } else {\n",
+       "        document\n",
+       "            .querySelector('[data-webio-mountpoint=\"17495209582925667918\"]')\n",
+       "            .innerHTML = (\n",
+       "                '<div style=\"padding: 1em; background-color: #f8d6da; border: 1px solid #f5c6cb\">' +\n",
+       "                '<p><strong>WebIO not detected.</strong></p>' +\n",
+       "                '<p>Please read ' +\n",
+       "                '<a href=\"https://juliagizmos.github.io/WebIO.jl/latest/troubleshooting/not-detected/\" target=\"_blank\">the troubleshooting guide</a> ' +\n",
+       "                'for more information on how to resolve this issue.</p>' +\n",
+       "                '<p><a href=\"https://juliagizmos.github.io/WebIO.jl/latest/troubleshooting/not-detected/\" target=\"_blank\">https://juliagizmos.github.io/WebIO.jl/latest/troubleshooting/not-detected/</a></p>' +\n",
+       "                '</div>'\n",
+       "            );\n",
+       "    }\n",
+       "    </script>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Scope(Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :label), Any[\"Kp\"], Dict{Symbol,Any}(:className => \"interact \",:style => Dict{Any,Any}(:padding => \"5px 10px 0px 10px\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-left\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :input), Any[], Dict{Symbol,Any}(:max => 33,:min => 1,:attributes => Dict{Any,Any}(:type => \"range\",Symbol(\"data-bind\") => \"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\" => \"horizontal\"),:step => 1,:className => \"slider slider is-fullwidth\",:style => Dict{Any,Any}()))], Dict{Symbol,Any}(:className => \"interact-flex-row-center\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :p), Any[], Dict{Symbol,Any}(:attributes => Dict(\"data-bind\" => \"text: formatted_val\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-right\"))], Dict{Symbol,Any}(:className => \"interact-flex-row interact-widget\")), Dict{String,Tuple{Observables.AbstractObservable,Union{Nothing, Bool}}}(\"changes\" => (Observable{Int64} with 1 listeners. Value:\n",
+       "0, nothing),\"index\" => (Observable{Any} with 2 listeners. Value:\n",
+       "17, nothing)), Set(String[]), nothing, Asset[Asset(\"js\", \"knockout\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout.js\"), Asset(\"js\", \"knockout_punches\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout_punches.js\"), Asset(\"js\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/all.js\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/style.css\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/Interact/SbgIk/src/../assets/bulma_confined.min.css\")], Dict{Any,Any}(\"changes\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\")],\"index\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\")]), WebIO.ConnectionPool(Channel{Any}(sz_max:32,sz_curr:0), Set(AbstractConnection[]), Base.GenericCondition{Base.AlwaysLockedST}(Base.InvasiveLinkedList{Task}(Task (runnable) @0x00007f39361d2980, Task (runnable) @0x00007f39361d2980), Base.AlwaysLockedST(1))), WebIO.JSString[WebIO.JSString(\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"7.0\\\",\\\"7.5\\\",\\\"8.0\\\",\\\"8.5\\\",\\\"9.0\\\",\\\"9.5\\\",\\\"10.0\\\",\\\"10.5\\\",\\\"11.0\\\",\\\"11.5\\\",\\\"12.0\\\",\\\"12.5\\\",\\\"13.0\\\",\\\"13.5\\\",\\\"14.0\\\",\\\"14.5\\\",\\\"15.0\\\",\\\"15.5\\\",\\\"16.0\\\",\\\"16.5\\\",\\\"17.0\\\",\\\"17.5\\\",\\\"18.0\\\",\\\"18.5\\\",\\\"19.0\\\",\\\"19.5\\\",\\\"20.0\\\",\\\"20.5\\\",\\\"21.0\\\",\\\"21.5\\\",\\\"22.0\\\",\\\"22.5\\\",\\\"23.0\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"5522547382221971813\\\",\\\"id\\\":\\\"ob_15\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"5522547382221971813\\\",\\\"id\\\":\\\"ob_14\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"5522547382221971813\\\",\\\"id\\\":\\\"ob_15\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"5522547382221971813\\\",\\\"id\\\":\\\"ob_14\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\")])], Dict{Symbol,Any}(:className => \"field interact-widget\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Scope(Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :label), Any[\"Td\"], Dict{Symbol,Any}(:className => \"interact \",:style => Dict{Any,Any}(:padding => \"5px 10px 0px 10px\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-left\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :input), Any[], Dict{Symbol,Any}(:max => 10,:min => 1,:attributes => Dict{Any,Any}(:type => \"range\",Symbol(\"data-bind\") => \"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\" => \"horizontal\"),:step => 1,:className => \"slider slider is-fullwidth\",:style => Dict{Any,Any}()))], Dict{Symbol,Any}(:className => \"interact-flex-row-center\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :p), Any[], Dict{Symbol,Any}(:attributes => Dict(\"data-bind\" => \"text: formatted_val\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-right\"))], Dict{Symbol,Any}(:className => \"interact-flex-row interact-widget\")), Dict{String,Tuple{Observables.AbstractObservable,Union{Nothing, Bool}}}(\"changes\" => (Observable{Int64} with 1 listeners. Value:\n",
+       "0, nothing),\"index\" => (Observable{Any} with 2 listeners. Value:\n",
+       "5, nothing)), Set(String[]), nothing, Asset[Asset(\"js\", \"knockout\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout.js\"), Asset(\"js\", \"knockout_punches\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout_punches.js\"), Asset(\"js\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/all.js\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/style.css\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/Interact/SbgIk/src/../assets/bulma_confined.min.css\")], Dict{Any,Any}(\"changes\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\")],\"index\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\")]), WebIO.ConnectionPool(Channel{Any}(sz_max:32,sz_curr:0), Set(AbstractConnection[]), Base.GenericCondition{Base.AlwaysLockedST}(Base.InvasiveLinkedList{Task}(Task (runnable) @0x00007f39361d3d00, Task (runnable) @0x00007f39361d3d00), Base.AlwaysLockedST(1))), WebIO.JSString[WebIO.JSString(\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"0.01\\\",\\\"0.02\\\",\\\"0.03\\\",\\\"0.04\\\",\\\"0.05\\\",\\\"0.06\\\",\\\"0.07\\\",\\\"0.08\\\",\\\"0.09\\\",\\\"0.1\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"5835400797425742633\\\",\\\"id\\\":\\\"ob_18\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"5835400797425742633\\\",\\\"id\\\":\\\"ob_17\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"5835400797425742633\\\",\\\"id\\\":\\\"ob_18\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"5835400797425742633\\\",\\\"id\\\":\\\"ob_17\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\")])], Dict{Symbol,Any}(:className => \"field interact-widget\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Scope(Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :label), Any[\"d0\"], Dict{Symbol,Any}(:className => \"interact \",:style => Dict{Any,Any}(:padding => \"5px 10px 0px 10px\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-left\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :input), Any[], Dict{Symbol,Any}(:max => 51,:min => 1,:attributes => Dict{Any,Any}(:type => \"range\",Symbol(\"data-bind\") => \"numericValue: index, valueUpdate: 'input', event: {change: function (){this.changes(this.changes()+1)}}\",\"orient\" => \"horizontal\"),:step => 1,:className => \"slider slider is-fullwidth\",:style => Dict{Any,Any}()))], Dict{Symbol,Any}(:className => \"interact-flex-row-center\")), Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Node{WebIO.DOM}(WebIO.DOM(:html, :p), Any[], Dict{Symbol,Any}(:attributes => Dict(\"data-bind\" => \"text: formatted_val\")))], Dict{Symbol,Any}(:className => \"interact-flex-row-right\"))], Dict{Symbol,Any}(:className => \"interact-flex-row interact-widget\")), Dict{String,Tuple{Observables.AbstractObservable,Union{Nothing, Bool}}}(\"changes\" => (Observable{Int64} with 1 listeners. Value:\n",
+       "0, nothing),\"index\" => (Observable{Any} with 2 listeners. Value:\n",
+       "26, nothing)), Set(String[]), nothing, Asset[Asset(\"js\", \"knockout\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout.js\"), Asset(\"js\", \"knockout_punches\", \"/home/reynolds/.julia/packages/Knockout/1sDlc/src/../assets/knockout_punches.js\"), Asset(\"js\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/all.js\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/InteractBase/9mFwe/src/../assets/style.css\"), Asset(\"css\", nothing, \"/home/reynolds/.julia/packages/Interact/SbgIk/src/../assets/bulma_confined.min.css\")], Dict{Any,Any}(\"changes\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"changes\\\"]()) ? (this.valueFromJulia[\\\"changes\\\"]=true, this.model[\\\"changes\\\"](val)) : undefined})\")],\"index\" => Any[WebIO.JSString(\"(function (val){return (val!=this.model[\\\"index\\\"]()) ? (this.valueFromJulia[\\\"index\\\"]=true, this.model[\\\"index\\\"](val)) : undefined})\")]), WebIO.ConnectionPool(Channel{Any}(sz_max:32,sz_curr:0), Set(AbstractConnection[]), Base.GenericCondition{Base.AlwaysLockedST}(Base.InvasiveLinkedList{Task}(Task (runnable) @0x00007f39363004f0, Task (runnable) @0x00007f39363004f0), Base.AlwaysLockedST(1))), WebIO.JSString[WebIO.JSString(\"function () {\\n    var handler = (function (ko, koPunches) {\\n    ko.punches.enableAll();\\n    ko.bindingHandlers.numericValue = {\\n        init: function(element, valueAccessor, allBindings, data, context) {\\n            var stringified = ko.observable(ko.unwrap(valueAccessor()));\\n            stringified.subscribe(function(value) {\\n                var val = parseFloat(value);\\n                if (!isNaN(val)) {\\n                    valueAccessor()(val);\\n                }\\n            });\\n            valueAccessor().subscribe(function(value) {\\n                var str = JSON.stringify(value);\\n                if ((str == \\\"0\\\") && ([\\\"-0\\\", \\\"-0.\\\"].indexOf(stringified()) >= 0))\\n                     return;\\n                 if ([\\\"null\\\", \\\"\\\"].indexOf(str) >= 0)\\n                     return;\\n                stringified(str);\\n            });\\n            ko.applyBindingsToNode(\\n                element,\\n                {\\n                    value: stringified,\\n                    valueUpdate: allBindings.get('valueUpdate'),\\n                },\\n                context,\\n            );\\n        }\\n    };\\n    var json_data = {\\\"formatted_vals\\\":[\\\"0.015\\\",\\\"0.0152\\\",\\\"0.0154\\\",\\\"0.0156\\\",\\\"0.0158\\\",\\\"0.016\\\",\\\"0.0162\\\",\\\"0.0164\\\",\\\"0.0166\\\",\\\"0.0168\\\",\\\"0.017\\\",\\\"0.0172\\\",\\\"0.0174\\\",\\\"0.0176\\\",\\\"0.0178\\\",\\\"0.018\\\",\\\"0.0182\\\",\\\"0.0184\\\",\\\"0.0186\\\",\\\"0.0188\\\",\\\"0.019\\\",\\\"0.0192\\\",\\\"0.0194\\\",\\\"0.0196\\\",\\\"0.0198\\\",\\\"0.02\\\",\\\"0.0202\\\",\\\"0.0204\\\",\\\"0.0206\\\",\\\"0.0208\\\",\\\"0.021\\\",\\\"0.0212\\\",\\\"0.0214\\\",\\\"0.0216\\\",\\\"0.0218\\\",\\\"0.022\\\",\\\"0.0222\\\",\\\"0.0224\\\",\\\"0.0226\\\",\\\"0.0228\\\",\\\"0.023\\\",\\\"0.0232\\\",\\\"0.0234\\\",\\\"0.0236\\\",\\\"0.0238\\\",\\\"0.024\\\",\\\"0.0242\\\",\\\"0.0244\\\",\\\"0.0246\\\",\\\"0.0248\\\",\\\"0.025\\\"],\\\"changes\\\":WebIO.getval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"4044788257546097905\\\",\\\"id\\\":\\\"ob_21\\\",\\\"type\\\":\\\"observable\\\"}),\\\"index\\\":WebIO.getval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"4044788257546097905\\\",\\\"id\\\":\\\"ob_20\\\",\\\"type\\\":\\\"observable\\\"})};\\n    var self = this;\\n    function AppViewModel() {\\n        for (var key in json_data) {\\n            var el = json_data[key];\\n            this[key] = Array.isArray(el) ? ko.observableArray(el) : ko.observable(el);\\n        }\\n        \\n        [this[\\\"formatted_val\\\"]=ko.computed(    function(){\\n        return this.formatted_vals()[parseInt(this.index())-(1)];\\n    }\\n,this)]\\n        [this[\\\"changes\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"changes\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"changes\\\",\\\"scope\\\":\\\"4044788257546097905\\\",\\\"id\\\":\\\"ob_21\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"changes\\\"]=false}),self),this[\\\"index\\\"].subscribe((function (val){!(this.valueFromJulia[\\\"index\\\"]) ? (WebIO.setval({\\\"name\\\":\\\"index\\\",\\\"scope\\\":\\\"4044788257546097905\\\",\\\"id\\\":\\\"ob_20\\\",\\\"type\\\":\\\"observable\\\"},val)) : undefined; return this.valueFromJulia[\\\"index\\\"]=false}),self)]\\n        \\n    }\\n    self.model = new AppViewModel();\\n    self.valueFromJulia = {};\\n    for (var key in json_data) {\\n        self.valueFromJulia[key] = false;\\n    }\\n    ko.applyBindings(self.model, self.dom);\\n}\\n);\\n    (WebIO.importBlock({\\\"data\\\":[{\\\"name\\\":\\\"knockout\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/7aa7b13c9453b8724d29f1aa1c360ef00484b43e-knockout.js\\\"},{\\\"name\\\":\\\"knockout_punches\\\",\\\"type\\\":\\\"js\\\",\\\"url\\\":\\\"/assetserver/bb8cd20f16584b32414e04255ba57aeff76e0f96-knockout_punches.js\\\"}],\\\"type\\\":\\\"async_block\\\"})).then((imports) => handler.apply(this, imports));\\n}\\n\")])], Dict{Symbol,Any}(:className => \"field interact-widget\")), Observable{Any} with 0 listeners. Value:\n",
+       "Node{WebIO.DOM}(WebIO.DOM(:html, :div), Any[Plot{Plots.GRBackend() n=2}], Dict{Symbol,Any}(:className => \"interact-flex-row interact-widget\"))], Dict{Symbol,Any}())"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {
+      "application/vnd.webio.node+json": {
+       "kernelId": "5c66a939-fe49-49f0-b4f0-78a0c78f0033"
+      }
+     },
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "using OMJulia, Plots, Interact\n",
     "\n",
     "mlNLPD = OMJulia.OMCSession()\n",
-    "mlNLPD.ModelicaSystem(\"MagLevNLPD.mo\",\"MagLevNLPD\")\n",
-    "mlNLPD.setSimulationOptions([\"stopTime=0.5\", \"tolerance=1e-8\"])\n",
+    "ModelicaSystem(mlNLPD,\"MagLevNLPD.mo\",\"MagLevNLPD\")\n",
+    "setSimulationOptions(mlNLPD,[\"stopTime=0.5\", \"tolerance=1e-8\"])\n",
     "gr(size=(700,300))\n",
     "@manipulate for Kp = 7:.5:23, Td = 0.01:.01:0.1, d0 = 0.015:0.0002:0.025\n",
-    "  mlNLPD.setParameters([\"Kp=$Kp\", \"Td=$Td\", \"d0=$d0\"])\n",
-    "  mlNLPD.simulate()\n",
-    "  sol = mlNLPD.getSolutions([\"time\", \"d\", \"v\"])\n",
+    "  setParameters(mlNLPD,[\"Kp=$Kp\", \"Td=$Td\", \"d0=$d0\"])\n",
+    "  simulate(mlNLPD)\n",
+    "  sol = getSolutions(mlNLPD,[\"time\", \"d\", \"v\"])\n",
     "  time, d, v = sol[1], sol[2], sol[3]\n",
     "  p1 = plot(time, d, label=\"\", xlabel=\"time [s]\", ylabel=\"d [m]\")\n",
     "  p2 = plot(time, v, label=\"\", xlabel=\"time [s]\", ylabel=\"v [V]\")\n",
@@ -543,39 +1845,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Error: Failed to load package Modelica_Synchronous (default) using MODELICAPATH /usr/bin/../lib/omlibrary:/home/reynolds/.openmodelica/libraries/.\n",
+      "LoadFile: /home/reynolds/Julia/MagLevApp/ML.moNotification: Skipped loading package Modelica_DeviceDrivers (1.6.0,default) using MODELICAPATH /usr/bin/../lib/omlibrary:/home/reynolds/.openmodelica/libraries/ (uses-annotation may be wrong).\n",
+      "[/home/reynolds/Julia/MagLevApp/ML.mo:7:5-8:68:writable] Error: Class Modelica_Synchronous.ClockSignals.Clocks.PeriodicRealClock not found in scope ML.MagLev_AVRcl.\n",
+      "Error: Error occurred while flattening model ML.MagLev_AVRcl\n"
+     ]
+    },
+    {
+     "ename": "Base.IOError",
+     "evalue": "IOError: could not spawn `./AVRcl -r=../res_Default.csv`: no such file or directory (ENOENT)",
+     "output_type": "error",
+     "traceback": [
+      "IOError: could not spawn `./AVRcl -r=../res_Default.csv`: no such file or directory (ENOENT)",
+      "",
+      "Stacktrace:",
+      " [1] _spawn_primitive(::String, ::Cmd, ::Array{Any,1}) at ./process.jl:99",
+      " [2] setup_stdios(::Base.var\"#554#555\"{Cmd}, ::Array{Any,1}) at ./process.jl:112",
+      " [3] _spawn at ./process.jl:111 [inlined]",
+      " [4] #run#565(::Bool, ::typeof(run), ::Cmd) at ./process.jl:439",
+      " [5] run(::Cmd) at ./process.jl:438",
+      " [6] top-level scope at In[12]:30"
+     ]
+    }
+   ],
    "source": [
     "using OMJulia\n",
     "AVRcl = OMJulia.OMCSession()\n",
     "\n",
-    "res = AVRcl.sendExpression(\"loadModel(Modelica)\")\n",
-    "if (!occursin(\"true\", res)) print(AVRcl.sendExpression(\"getErrorString()\")) end\n",
+    "if !sendExpression(AVRcl,\"loadModel(Modelica)\")\n",
+    "    print(AVRcl.sendExpression(\"getErrorString()\")) end\n",
     "\n",
-    "res = AVRcl.sendExpression(\"loadModel(Modelica_Synchronous)\")\n",
-    "if (occursin(\"true\", res))\n",
-    "    res = AVRcl.sendExpression(\"getSourceFile(Modelica_Synchronous)\")\n",
-    "    print(\"LoadModel: \" * res)\n",
+    "if sendExpression(AVRcl,\"loadModel(Modelica_Synchronous)\")\n",
+    "    res = sendExpression(AVRcl,\"getSourceFile(Modelica_Synchronous)\")\n",
+    "    print(\"LoadModel: \" * string(res))\n",
     "else\n",
-    "    print(AVRcl.sendExpression(\"getErrorString()\"))\n",
+    "    print(sendExpression(AVRcl,\"getErrorString()\"))\n",
     "end\n",
     "\n",
-    "res = AVRcl.sendExpression(\"loadFile(\\\"ML.mo\\\")\")\n",
-    "if (occursin(\"true\", res))\n",
-    "    res = AVRcl.sendExpression(\"getSourceFile(ML)\")\n",
-    "    print(\"LoadFile: \" * res)\n",
+    "if sendExpression(AVRcl,\"loadFile(\\\"ML.mo\\\")\")\n",
+    "    res = sendExpression(AVRcl,\"getSourceFile(ML)\")\n",
+    "    print(\"LoadFile: \" * string(res))\n",
     "else\n",
-    "    print(AVRcl.sendExpression(\"getErrorString()\"))\n",
+    "    print(sendExpression(AVRcl,\"getErrorString()\"))\n",
     "end\n",
     "\n",
-    "res = AVRcl.sendExpression(\"setLanguageStandard(\\\"latest\\\")\")\n",
-    "if (!occursin(\"true\", res)) print(AVRcl.sendExpression(\"getErrorString()\")) end\n",
+    "if !sendExpression(AVRcl,\"setLanguageStandard(\\\"latest\\\")\")\n",
+    "    print(sendExpression(AVRcl,\"getErrorString()\")) end\n",
     "\n",
     "mkpath(\"simdir\")\n",
-    "AVRcl.sendExpression(\"cd(\\\"simdir\\\")\")\n",
-    "res = AVRcl.sendExpression(\"buildModel(ML.MagLev_AVRcl, stopTime=5.0, fileNamePrefix=\\\"AVRcl\\\", outputFormat=\\\"csv\\\")\")\n",
-    "print(AVRcl.sendExpression(\"getErrorString()\"))\n",
+    "sendExpression(AVRcl,\"cd(\\\"simdir\\\")\")\n",
+    "res = sendExpression(AVRcl,\"buildModel(ML.MagLev_AVRcl, stopTime=5.0, fileNamePrefix=\\\"AVRcl\\\", outputFormat=\\\"csv\\\")\")\n",
+    "print(sendExpression(AVRcl,\"getErrorString()\"))\n",
     "\n",
     "cd(\"simdir\")\n",
     "run(`./AVRcl -r=../res_Default.csv`)\n",
@@ -593,9 +1920,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ArgumentError",
+     "evalue": "ArgumentError: \"res_Default.csv\" is not a valid file",
+     "output_type": "error",
+     "traceback": [
+      "ArgumentError: \"res_Default.csv\" is not a valid file",
+      "",
+      "Stacktrace:",
+      " [1] checkvalidsource at /home/reynolds/.julia/packages/CSV/4GOjG/src/CSV.jl:142 [inlined]",
+      " [2] file(::String, ::Int64, ::Bool, ::Int64, ::Nothing, ::Int64, ::Int64, ::Bool, ::Nothing, ::Bool, ::Bool, ::Array{String,1}, ::String, ::Nothing, ::Bool, ::Char, ::Nothing, ::Nothing, ::Char, ::Nothing, ::UInt8, ::Nothing, ::Nothing, ::Nothing, ::Nothing, ::Dict{Int8,Int8}, ::Bool, ::Float64, ::Bool, ::Bool, ::Nothing, ::Bool, ::Bool, ::Nothing) at /home/reynolds/.julia/packages/CSV/4GOjG/src/CSV.jl:310",
+      " [3] #File#15 at /home/reynolds/.julia/packages/CSV/4GOjG/src/CSV.jl:260 [inlined]",
+      " [4] File at /home/reynolds/.julia/packages/CSV/4GOjG/src/CSV.jl:260 [inlined]",
+      " [5] #read#66 at /home/reynolds/.julia/packages/CSV/4GOjG/src/CSV.jl:1084 [inlined]",
+      " [6] read(::String) at /home/reynolds/.julia/packages/CSV/4GOjG/src/CSV.jl:1084",
+      " [7] top-level scope at In[13]:3"
+     ]
+    }
+   ],
    "source": [
     "using Plots, CSV, LaTeXStrings\n",
     "pyplot()\n",
@@ -680,16 +2025,20 @@
   }
  ],
  "metadata": {
+  "@webio": {
+   "lastCommId": "94c66b699eb0402d83ae040fd5556359",
+   "lastKernelId": "5c35a98c-7868-45e2-ba01-626306014f0d"
+  },
   "kernelspec": {
-   "display_name": "Julia 1.1.0",
+   "display_name": "Julia 1.3.1",
    "language": "julia",
-   "name": "julia-1.1"
+   "name": "julia-1.3"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.1.0"
+   "version": "1.3.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The calls to OMCSession and ModelicaSystem are now no longer to be used as classes like in Python:
```
mod = ModelicaSystems(...)
mod.getXXX(...)
```
but in Julia style as functions
```
mod = ModelicaSystems(...)
getXXX(mod, ...)
```
All errors have been resolved, except of the last two cells which I couldn't execute due to a missing library.